### PR TITLE
Fix session token handling from credentials file

### DIFF
--- a/src/get-creds.js
+++ b/src/get-creds.js
@@ -46,7 +46,7 @@ async function getCredsFromFile (params) {
     let {
       aws_access_key_id: accessKeyId,
       aws_secret_access_key: secretAccessKey,
-      aws_session_toke: sessionToken,
+      aws_session_token: sessionToken,
     } = creds[profile]
 
     return validate({ accessKeyId, secretAccessKey, sessionToken })

--- a/test/mock/.aws/credentials
+++ b/test/mock/.aws/credentials
@@ -5,3 +5,4 @@ aws_secret_access_key=default_aws_secret_access_key
 [profile_1]
 aws_access_key_id=profile_1_aws_access_key_id
 aws_secret_access_key=profile_1_aws_secret_access_key
+aws_session_token=profile_1_aws_session_token

--- a/test/unit/src/get-creds-test.js
+++ b/test/unit/src/get-creds-test.js
@@ -87,7 +87,7 @@ test('Get credentials from credentials file', async t => {
   let nonDefaultProfile = {
     accessKeyId: 'profile_1_aws_access_key_id',
     secretAccessKey: 'profile_1_aws_secret_access_key',
-    sessionToken: undefined
+    sessionToken: 'profile_1_aws_session_token'
   }
 
   // Default credentials file location


### PR DESCRIPTION
There was a typo when reading session token from `.aws/credentials` profile. Wasn't being tested via the unit tests, so added a failing test then fixed the bug.