### PR TITLE
Add support for "external process"-sourced credentials

### DIFF
--- a/src/get-creds.js
+++ b/src/get-creds.js
@@ -1,6 +1,7 @@
 let { readFile } = require('fs/promises')
 let { exists } = require('./lib')
 let { join } = require('path')
+let { execSync } = require('child_process')
 let os = require('os')
 let ini = require('ini')
 
@@ -43,11 +44,24 @@ async function getCredsFromFile (params) {
     if (!creds[profile]) {
       throw TypeError(`Profile not found: ${profile}`)
     }
-    let {
-      aws_access_key_id: accessKeyId,
-      aws_secret_access_key: secretAccessKey,
-      aws_session_toke: sessionToken,
-    } = creds[profile]
+
+    let accessKeyId
+    let secretAccessKey
+    let sessionToken
+    if (creds[profile].credential_process) {
+      ({
+        AccessKeyId: accessKeyId,
+        SecretAccessKey: secretAccessKey,
+        SessionToken: sessionToken,
+      } = JSON.parse(execSync(creds[profile].credential_process, { encoding: 'utf8' })))
+    }
+    else {
+      ({
+        aws_access_key_id: accessKeyId,
+        aws_secret_access_key: secretAccessKey,
+        aws_session_toke: sessionToken,
+      } = creds[profile])
+    }
 
     return validate({ accessKeyId, secretAccessKey, sessionToken })
   }

--- a/test/mock/.aws/credentials
+++ b/test/mock/.aws/credentials
@@ -5,3 +5,6 @@ aws_secret_access_key=default_aws_secret_access_key
 [profile_1]
 aws_access_key_id=profile_1_aws_access_key_id
 aws_secret_access_key=profile_1_aws_secret_access_key
+
+[profile_2]
+credential_process = echo '{"AccessKeyId":"profile_2_aws_access_key_id","SecretAccessKey":"profile_2_aws_secret_access_key"}'

--- a/test/unit/src/get-creds-test.js
+++ b/test/unit/src/get-creds-test.js
@@ -74,10 +74,11 @@ test('Get credentials from env vars', async t => {
 })
 
 test('Get credentials from credentials file', async t => {
-  t.plan(5)
+  t.plan(6)
   resetAWSEnvVars()
   let result
   let profile = 'profile_1'
+  let processProfile = 'profile_2'
 
   let defaultProfile = {
     accessKeyId: 'default_aws_access_key_id',
@@ -87,6 +88,11 @@ test('Get credentials from credentials file', async t => {
   let nonDefaultProfile = {
     accessKeyId: 'profile_1_aws_access_key_id',
     secretAccessKey: 'profile_1_aws_secret_access_key',
+    sessionToken: undefined
+  }
+  let processProfileCreds = {
+    accessKeyId: 'profile_2_aws_access_key_id',
+    secretAccessKey: 'profile_2_aws_secret_access_key',
     sessionToken: undefined
   }
 
@@ -116,6 +122,12 @@ test('Get credentials from credentials file', async t => {
   process.env.AWS_PROFILE = profile
   result = await getCreds({})
   t.deepEqual(result, nonDefaultProfile, 'Returned correct credentials from credentials file (AWS_PROFILE env var)')
+  resetAWSEnvVars()
+
+  // credentials from a process
+  process.env.AWS_SHARED_CREDENTIALS_FILE = credentialsMock
+  result = await getCreds({ profile: processProfile })
+  t.deepEqual(result, processProfileCreds, 'Returned correct credentials from credentials file (params.profile)')
   resetAWSEnvVars()
 
   // Credential file checks are skipped in Lambda


### PR DESCRIPTION
AWS offer the option to source credentials from an external process, which is handy for using things like 1Password to hold your credentials.

This adds support to `getCreds` so these can be read, via a call to `execSync`. Technically this is a bit bad in that we're passing a random string to `exec`, but to make this work there isn't really much option and AWS mention this themselves in their own documentation, so "with great power" etc. etc.

https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
