### PR TITLE
Add support for overriding the response content type on a client

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,6 +146,8 @@ The following options may be passed when instantiating the `aws-lite` client:
   - Set a custom port number to use, helpful for local testing
 - **`protocol` (string) [default = `https`]**
   - Set the connection protocol to `http`, helpful for local testing
+- **`responseContentType` (string)**
+  - Set an overriding Content-Type header for all responses, helpful for local testing 
 
 An example:
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,6 +16,7 @@ declare module "@aws-lite/client" {
     plugins?: any[];
     port?: number;
     protocol?: string;
+    responseContentType?: string;
   }
 
   interface AwsLiteRequest {

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ let clientFactory = require('./client-factory')
  * @param {string} [config.protocol='https'] Set the connection protocol to 'http', helpful for local testing
  * @param {string} [config.host] Set a custom host name to use, helpful for local testing
  * @param {number} [config.port] Set a custom port number to use, helpful for local testing
+ * @param {string} [config.responseContentType] Set an overriding Content-Type headers for responses, helpful for local testing
  * @param {array} [config.plugins] Define AWS service plugins; by default, `@aws-lite/*` + `aws-lite-plugin-*` plugins are auto-loaded; specifying this option disables plugin auto-loading
  *
  * @returns {Promise<function>} Client async function

--- a/src/request.js
+++ b/src/request.js
@@ -165,7 +165,7 @@ function request (params, creds, region, config, metadata) {
       res.on('data', chunk => data.push(chunk))
       res.on('end', () => {
         let body = Buffer.concat(data), payload, rawString
-        let contentType = headers['content-type'] || headers['Content-Type'] || ''
+        let contentType = config.responseContentType || headers['content-type'] || headers['Content-Type'] || ''
         if (JSONContentType(contentType) || AwsJSONContentType(contentType)) {
           payload = JSON.parse(body)
 

--- a/test/unit/src/index-plugins-test.js
+++ b/test/unit/src/index-plugins-test.js
@@ -229,7 +229,7 @@ test('Plugins - method construction, request()', async t => {
 })
 
 test('Plugins - response()', async t => {
-  t.plan(77)
+  t.plan(83)
   let aws, payload, response, responseBody, responseHeaders
 
   aws = await client({ ...config, host, port, plugins: [ join(pluginDir, 'response.js') ] })
@@ -309,6 +309,18 @@ test('Plugins - response()', async t => {
   t.ok(response.headers, 'Response headers passed through')
   t.notOk(response.headers.foo, 'Response headers not mutated')
   t.equal(response.payload, null, 'Response payload passed through')
+  basicRequestChecks(t, 'GET', { url: '/' })
+
+  // Force content type on response
+  aws = await client({ ...config, responseContentType: 'application/json', plugins: [ join(pluginDir, 'response.js') ] })
+  console.log(aws)
+
+  // Response is forced to another content-type and parsed appropriately
+  responseHeaders = { 'content-type': '*/*' }
+  payload = { hi: 'there' }
+  server.use({ responseHeaders, responseBody: JSON.stringify(payload) })
+  response = await aws.lambda.Passthrough()
+  t.deepEqual(response.payload, payload, 'Returned response payload parsed despite wrong content-type')
   basicRequestChecks(t, 'GET', { url: '/' })
 })
 


### PR DESCRIPTION
Whilst developing a plugin locally, I used a local AWS service emulator for some initial rapid local dev, but the emulator in question is particularly poor in terms of following AWS like-for-like, and returns JSON with a '*/*' content type header.

I've added an extra config option for the `aws-lite` client, `responseContentType` which, when set, will override whatever content type is sent back before any other tasks run, such as auto parsing JSON and XML.

This allows me to set something locally to dev against an emulator and not have to add a call to `JSON.parse` in `response()` which would then have to be removed for live usage.

Readme has been updated to document the option, addition test added, TypeScript and JSDoc updated too.