### PR TITLE
Add missing example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -172,6 +172,7 @@ aws = await awsLite({
   plugins: [ '@aws-lite/dynamodb', '/a/custom/local/plugin/path' ],
   port: 12345,
   protocol: 'http',
+  responseContentType: 'application/json',
 })
 ```
 


### PR DESCRIPTION
Missed adding the extra config parameter to the maximal example in the readme, apologies.