### PR TITLE
Add missing plugin to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -538,6 +538,7 @@ async function request (params, utils) {
 <!-- ! Do not remove plugins_start / plugins_end ! -->
 <!-- plugins_start -->
 - [DynamoDB](https://www.npmjs.com/package/@aws-lite/dynamodb)
+- [RDS Data Service](https://www.npmjs.com/package/@aws-lite/rds-data)
 - [S3](https://www.npmjs.com/package/@aws-lite/s3)
 - [SSM](https://www.npmjs.com/package/@aws-lite/ssm)
 <!-- plugins_end -->


### PR DESCRIPTION
I think this didn't automatically pull through because it's a feature of using the script to start writing a plugin, which I missed in the readme when I started this.