### PR TITLE
Fix/Improve Type Definitions for CommonJS

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,55 +1,55 @@
 // https://www.typescriptlang.org/docs/handbook/modules.html#working-with-other-javascript-libraries
 // 'We call declarations that don't define an implementation "ambient".'
 
+interface AwsLiteConfig {
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+  region?: string;
+  profile?: string;
+  autoloadPlugins?: boolean;
+  awsConfigFile?: boolean | string;
+  debug?: boolean;
+  endpointPrefix?: string;
+  host?: string;
+  keepAlive?: boolean;
+  plugins?: any[];
+  port?: number;
+  protocol?: string;
+  responseContentType?: string;
+}
+
+interface AwsLiteRequest {
+  service: string;
+  awsjson?: boolean | string[];
+  endpoint?: string;
+  headers?: Record<string, string>;
+  payload?: Record<string, any> | Buffer | ReadableStream | string;
+  /** @description Alias for "payload" */
+  body?: Record<string, any> | Buffer | ReadableStream | string;
+  /** @description Alias for "payload" */
+  data?: Record<string, any> | Buffer | ReadableStream | string;
+  /** @description Alias for "payload" */
+  json?: Record<string, any> | Buffer | ReadableStream | string;
+  query?: Record<string, any>;
+  region?: string;
+  protocol?: string;
+  host?: string;
+  port?: number;
+}
+
+interface AwsLiteResponse {
+  headers: Record<string, string>;
+  payload: Record<string, any>;
+  statusCode: number;
+}
+
+// must be exported so that plugins types can extend it
+export interface AwsLiteClient {
+  (payload: AwsLiteRequest): Promise<AwsLiteResponse>;
+}
+
 declare module "@aws-lite/client" {
-  export interface AwsLiteConfig {
-    accessKeyId?: string;
-    secretAccessKey?: string;
-    sessionToken?: string;
-    region?: string;
-    profile?: string;
-    autoloadPlugins?: boolean;
-    awsConfigFile?: boolean | string;
-    debug?: boolean;
-    endpointPrefix?: string;
-    host?: string;
-    keepAlive?: boolean;
-    plugins?: any[];
-    port?: number;
-    protocol?: string;
-    responseContentType?: string;
-  }
-
-  export interface AwsLiteRequest {
-    service: string;
-    awsjson?: boolean | string[];
-    endpoint?: string;
-    headers?: Record<string, string>;
-    payload?: Record<string, any> | Buffer | ReadableStream | string;
-    /** @description Alias for "payload" */
-    body?: Record<string, any> | Buffer | ReadableStream | string;
-    /** @description Alias for "payload" */
-    data?: Record<string, any> | Buffer | ReadableStream | string;
-    /** @description Alias for "payload" */
-    json?: Record<string, any> | Buffer | ReadableStream | string;
-    query?: Record<string, any>;
-    region?: string;
-    protocol?: string;
-    host?: string;
-    port?: number;
-  }
-
-
-  export interface AwsLiteResponse {
-    headers: Record<string, string>;
-    payload: Record<string, any>;
-    statusCode: number;
-  }
-
-  export interface AwsLiteClient {
-    (payload: AwsLiteRequest): Promise<AwsLiteResponse>;
-  }
-
-  const AwsLite: (config?: AwsLiteConfig) => Promise<AwsLiteClient>;
-  export = AwsLite;
+  const CreateAwsLite: (config?: AwsLiteConfig) => Promise<AwsLiteClient>;
+  export = CreateAwsLite;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,7 +2,7 @@
 // 'We call declarations that don't define an implementation "ambient".'
 
 declare module "@aws-lite/client" {
-  interface AwsLiteConfig {
+  export interface AwsLiteConfig {
     accessKeyId?: string;
     secretAccessKey?: string;
     sessionToken?: string;
@@ -20,7 +20,7 @@ declare module "@aws-lite/client" {
     responseContentType?: string;
   }
 
-  interface AwsLiteRequest {
+  export interface AwsLiteRequest {
     service: string;
     awsjson?: boolean | string[];
     endpoint?: string;
@@ -40,15 +40,16 @@ declare module "@aws-lite/client" {
   }
 
 
-  interface AwsLiteResponse {
+  export interface AwsLiteResponse {
     headers: Record<string, string>;
     payload: Record<string, any>;
     statusCode: number;
   }
 
-  interface AwsLiteClient {
+  export interface AwsLiteClient {
     (payload: AwsLiteRequest): Promise<AwsLiteResponse>;
   }
 
-  export default function AwsLite(config?: AwsLiteConfig): Promise<AwsLiteClient>;
+  const AwsLite: (config?: AwsLiteConfig) => Promise<AwsLiteClient>;
+  export = AwsLite;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,3 @@
-// https://www.typescriptlang.org/docs/handbook/modules.html#working-with-other-javascript-libraries
-// 'We call declarations that don't define an implementation "ambient".'
-
 interface AwsLiteConfig {
   accessKeyId?: string;
   secretAccessKey?: string;
@@ -44,7 +41,7 @@ interface AwsLiteResponse {
   statusCode: number;
 }
 
-// must be exported so that plugins types can extend it
+// export to allow <plugin>-types to extend AwsLiteClient
 export interface AwsLiteClient {
   (payload: AwsLiteRequest): Promise<AwsLiteResponse>;
 }


### PR DESCRIPTION
This is a known issue discovered by @filmaj and we confirmed it together in a CommonJS execution environment.

It may also address #70 

NOTE: there's nothing wrong with `aws-lite`'s execution in CJS, but the TS Lang Server that powers autocomplete for things like VS Code's Intellisense doesn't get the right typings when `require()`ing aws-lite.

~~I'm not thrilled with this change yet, and will update as I discover more, but early feedback is definitely welcome.~~
Further updates have made both user-land and the TS lang server happy. See comments below.

<details closed>

<summary>PR Template</summary>

## Summary

instead of `export default` use `export = `

however, this breaks the ambient type extensions provided by plugin types packages.

until the `interface`s are also exported.

TS seems to hate this multi-export approach but the consumer likes it and all types are accounted for.

---

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] ~~Forked the repo and created your branch from `master`~~
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!

</details>