### PR TITLE
Fix S3 plugin and tests to work with virtual host-style bucket addressing

### DIFF
--- a/plugins/s3/src/index.mjs
+++ b/plugins/s3/src/index.mjs
@@ -26,7 +26,7 @@ const Key = { ...str, required, comment: 'S3 key / file name' }
 const PartNumber = { ...num, comment: 'Part number (between 1 - 10,000) of the object' }
 const VersionId = { ...str, comment: 'Reference a specific version of the object' }
 
-const host = (Bucket, region, host) => host ? `${Bucket}.${host}` : `${Bucket}.s3.${region}.amazonaws.com`
+const host = (Bucket, region, host) => `${Bucket}.` + (host || `s3.${region}.amazonaws.com`)
 const defaultResponse = ({ payload }) => payload
 const defaultError = ({ statusCode, error }) => {
   // SDK v2 lowcases `code`


### PR DESCRIPTION
1. Configure s3rver to work with virtual-host bucket addressing.
2. Fix S3 plugin to correctly build host for API request.
3. Add `CreateBucket` to S3 tests.

Tests now run successfully, no "is testing" condition, and I manually tested against both Amazon S3 and Backblaze B2.