### PR TITLE
Add tests for untested S3 operations

### DIFF
--- a/plugins/s3/src/index.mjs
+++ b/plugins/s3/src/index.mjs
@@ -27,7 +27,7 @@ const PartNumber = { ...num, comment: 'Part number (between 1 - 10,000) of the o
 const VersionId = { ...str, comment: 'Reference a specific version of the object' }
 
 const host = ({ Bucket }, { region, config }) => `${Bucket}.` + (config.host || `s3.${region}.amazonaws.com`)
-const defaultResponse = ({ payload }) => payload
+const defaultResponse = ({ payload }) => payload || {}
 const defaultError = ({ statusCode, error }) => {
   // SDK v2 lowcases `code`
   if (error?.Code) {


### PR DESCRIPTION
Add tests for previously untested S3 operations:

- `HeadBucket`
- `PutObject` (with `Body` property)
- `DeleteObject`
- `DeleteObjects`
- `DeleteBucket`

Modified S3 plugin's `defaultResponse` (used by `DeleteObject` and `DeleteObjects`) to return an empty object if `payload` is falsy. This makes `DeleteObject` consistent with other operations that return an empty object on success such as `HeadObject` and `DeleteBucket`.