### PR TITLE
DeleteObject should not set Content-Type header

### DIFF
--- a/plugins/s3/src/index.mjs
+++ b/plugins/s3/src/index.mjs
@@ -104,7 +104,7 @@ const DeleteObject = {
       host,
       pathPrefix,
       path: `/${Key}`,
-      headers: { ...xml, ...getHeadersFromParams(params) },
+      headers: { ...getHeadersFromParams(params) },
     }
   },
   response: defaultResponse,


### PR DESCRIPTION
S3 DeleteObject should not set the `Content-Type` header, since it does not send a body in the request.

(I discovered this when working on presigned URLs - including `Content-Type` in the signature, then not setting it in the `DELETE` HTTP request causes signature verification to fail.)