### PR TITLE
Presigned URLs

### DIFF
--- a/plugins/s3/src/index.mjs
+++ b/plugins/s3/src/index.mjs
@@ -104,7 +104,7 @@ const DeleteObject = {
       host,
       pathPrefix,
       path: `/${Key}`,
-      headers: { ...xml, ...getHeadersFromParams(params) },
+      headers: { ...getHeadersFromParams(params) },
     }
   },
   response: defaultResponse,

--- a/readme.md
+++ b/readme.md
@@ -154,6 +154,18 @@ await aws.DynamoDB.GetItem({
 //     ...
 //   }
 // }
+
+/**
+ * Presigned URLs
+ * Set signQuery property to true to get a presigned URL instead of making a request
+ */
+await aws.S3.GetObject({
+  Bucket: 'my-bucket',
+  Key: 'aws-lite.txt',
+  signQuery: true,
+  query: {'X-Amz-Expires': 3600},
+})
+// https://my-bucket.s3.us-west-1.amazonaws.com/aws-lite.txt?X-Amz-Expires=3600&X-Amz-Date=20240201T023407Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAXSRWQ36HL4DYYSGB%2F20240201%2Fus-west-1%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=6af04db66cbedb79e8bad6e8f84a2dbdb3e946c8f612845ce2215f90ffa1cd07
 ```
 
 ## Learn more

--- a/src/client-factory.js
+++ b/src/client-factory.js
@@ -170,6 +170,9 @@ module.exports = async function clientFactory (config, creds, region) {
             // Make the request
             try {
               let response = await request({ ...params, service }, creds, selectedRegion, config, metadata)
+              if (input.signQuery) {
+                return response
+              }
 
               // Run plugin.method.response()
               if (method.response) {

--- a/src/lib.js
+++ b/src/lib.js
@@ -119,6 +119,11 @@ function tidyQuery (obj) {
   if (Object.keys(tidied).length) return qs.stringify(tidied)
 }
 
+function untidyQuery (queries) {
+  let qs = require('querystring')
+  return qs.parse(queries)
+}
+
 // Probably this is going to need some refactoring in Arc 11
 // Certainly it is not reliable in !Arc local Lambda emulation
 let nonLocalEnvs = [ 'staging', 'production' ]
@@ -229,6 +234,7 @@ module.exports = {
   loadAwsConfig,
   readConfig,
   tidyQuery,
+  untidyQuery,
   useAWS,
   buildXML,
   parseXML,

--- a/src/request.js
+++ b/src/request.js
@@ -1,6 +1,6 @@
 let aws4 = require('aws4')
 let { globalServices, semiGlobalServices } = require('./services')
-let { awsjson, buildXML, getEndpointParams, parseXML, tidyQuery, useAWS, validateProtocol } = require('./lib')
+let { awsjson, buildXML, getEndpointParams, parseXML, tidyQuery, untidyQuery, useAWS, validateProtocol } = require('./lib')
 
 /* istanbul ignore next */
 let copy = obj => JSON.parse(JSON.stringify(obj))
@@ -162,14 +162,8 @@ function request (params, creds, region, config, metadata) {
       options.protocol = isHTTPS ? 'https:' : 'http:'
     }
 
-    /* istanbul ignore next */
-    let http = isHTTPS ? require('https') : require('http')
-
     // Port configuration
     options.port = params.port || config.port
-
-    // Disable keep-alive locally (or wait Node's default 5s for sockets to time out)
-    options.agent = getAgent(http, isHTTPS, config)
 
     /* istanbul ignore next */
     if (debug) {
@@ -181,26 +175,49 @@ function request (params, creds, region, config, metadata) {
 
       let { accessKeyId, secretAccessKey } = creds
 
-      let Authorization = headers.Authorization
-        .replace(accessKeyId, accessKeyId.substring(0, 8) + '...')
-        .replace(secretAccessKey, '[redacted]')
+      let debugHeaders, debugPath
+      if (options.signQuery) {
+        debugHeaders = headers
+        let query = untidyQuery(path.split('?')[1])
+        query['X-Amz-Signature'] = query['X-Amz-Signature'].substring(0, 8) + '...'
+        debugPath = tidyQuery(query)
+      }
+      else {
+        let Authorization = headers.Authorization
+          .replace(accessKeyId, accessKeyId.substring(0, 8) + '...')
+          .replace(secretAccessKey, '[redacted]')
 
-      let sigRe = /(Signature=)[^,]*/
-      let fullSig = Authorization.match(sigRe)
-      if (fullSig) {
-        let redactedSig = 'Signature=' + fullSig[0].split('Signature=')[1].substring(0, 8) + '...'
-        Authorization = Authorization.replace(sigRe, redactedSig)
+        let sigRe = /(Signature=)[^,]*/
+        let fullSig = Authorization.match(sigRe)
+        if (fullSig) {
+          let redactedSig = 'Signature=' + fullSig[0].split('Signature=')[1].substring(0, 8) + '...'
+          Authorization = Authorization.replace(sigRe, redactedSig)
+        }
+
+        debugHeaders = { ...headers, Authorization }
+        debugPath = path
       }
 
       console.error('[aws-lite] Request:', {
         time: new Date().toISOString(),
         service,
         method,
-        url: `${protocol}//${host}${port ? ':' + port : ''}${path}`,
-        headers: { ...headers, Authorization },
+        url: `${protocol}//${host}${port ? ':' + port : ''}${debugPath}`,
+        headers: debugHeaders,
         body: truncatedBody || '<no body>',
       }, '\n')
     }
+
+    if (params.signQuery) {
+      resolve(`${options.protocol}//${options.host}${options.path}`)
+      return
+    }
+
+    /* istanbul ignore next */
+    let http = isHTTPS ? require('https') : require('http')
+
+    // Disable keep-alive locally (or wait Node's default 5s for sockets to time out)
+    options.agent = getAgent(http, isHTTPS, config)
 
     let req = http.request(options, res => {
       let data = []


### PR DESCRIPTION
First stab at presigned URLs.

Invoked just like a regular request, but include `SignQuery: true` and, optionally, additional parameters for aws4. Method returns a string containing the presigned URL rather than the response to the query.

For example, generate presigned URL with a lifetime of one hour:

```javascript
url = await aws.S3.GetObject({
  Bucket: 'my-bucket',
  Key: 'aws-lite.txt',
  SignQuery: true,
  PresignedUrlExpires: 3600,
})

// https://my-bucket.s3.us-east-1.amazonaws.com/aws-lite.txt?X-Amz-Expires=3600&X-Amz-Date=20240201T213629Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAXSRWQ36HL4DYYSGB%2F20240201%2Fus-west-1%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=afea02734775bd678875705abc1999ba7811fe5390d4ba4a295ea1261aed2c7f
```

Rationale for this approach: generating a presigned URL needs all the same processing as a request until the `aws4.sign()` call. The path of least resistance is to execute that same code path, then bail out after `aws4.sign()` with the resulting URL, rather than making the request.

I'm very open to suggestions of a better developer experience. Now that this is working, it should be straightforward to refactor to a different approach.