### PR TITLE
export the plugin's main interface type

### DIFF
--- a/plugins/apigateway/types/index.d.ts
+++ b/plugins/apigateway/types/index.d.ts
@@ -19,6 +19,7 @@ declare module "@aws-lite/client" {
 }
 
 export type {
+  AwsLiteAPIGateway,
   /* ! Do not remove EXPORT_START / EXPORT_END ! */
   // $EXPORT_START
 

--- a/plugins/apigatewaymanagementapi/types/index.d.ts
+++ b/plugins/apigatewaymanagementapi/types/index.d.ts
@@ -38,6 +38,7 @@ declare module "@aws-lite/client" {
 }
 
 export type {
+  AwsLiteApiGatewayManagementApi,
   /* ! Do not remove EXPORT_START / EXPORT_END ! */
   // $EXPORT_START
   PostToConnectionResponse,

--- a/plugins/apigatewayv2/types/index.d.ts
+++ b/plugins/apigatewayv2/types/index.d.ts
@@ -45,6 +45,7 @@ declare module "@aws-lite/client" {
 }
 
 export type {
+  AwsLiteAPIGatewayV2,
   /* ! Do not remove EXPORT_START / EXPORT_END ! */
   // $EXPORT_START
   CreateDeploymentResponse,

--- a/plugins/cloudformation/types/index.d.ts
+++ b/plugins/cloudformation/types/index.d.ts
@@ -59,6 +59,7 @@ declare module "@aws-lite/client" {
 }
 
 export type {
+  AwsLiteCloudFormation,
   /* ! Do not remove EXPORT_START / EXPORT_END ! */
   // $EXPORT_START
   CreateStackResponse,

--- a/plugins/cloudfront/types/index.d.ts
+++ b/plugins/cloudfront/types/index.d.ts
@@ -66,6 +66,7 @@ declare module "@aws-lite/client" {
 }
 
 export type {
+  AwsLiteCloudFront,
   /* ! Do not remove EXPORT_START / EXPORT_END ! */
   // $EXPORT_START
   CreateDistributionResponse,

--- a/plugins/cloudwatch-logs/types/index.d.ts
+++ b/plugins/cloudwatch-logs/types/index.d.ts
@@ -45,6 +45,7 @@ declare module "@aws-lite/client" {
 }
 
 export type {
+  AwsLiteCloudWatchLogs,
   /* ! Do not remove EXPORT_START / EXPORT_END ! */
   // $EXPORT_START
   DeleteLogGroupResponse,

--- a/plugins/dynamodb/types/index.d.ts
+++ b/plugins/dynamodb/types/index.d.ts
@@ -380,6 +380,7 @@ declare module "@aws-lite/client" {
 }
 
 export type {
+  AwsLiteDynamoDB,
   /* ! Do not remove EXPORT_START / EXPORT_END ! */
   // $EXPORT_START
   BatchExecuteStatementResponse,

--- a/plugins/lambda/types/index.d.ts
+++ b/plugins/lambda/types/index.d.ts
@@ -66,6 +66,7 @@ declare module "@aws-lite/client" {
 }
 
 export type {
+  AwsLiteLambda,
   /* ! Do not remove EXPORT_START / EXPORT_END ! */
   // $EXPORT_START
   CreateFunctionResponse,

--- a/plugins/rds-data/types/index.d.ts
+++ b/plugins/rds-data/types/index.d.ts
@@ -55,6 +55,7 @@ declare module "@aws-lite/client" {
 }
 
 export type {
+  AwsLiteRDSData,
   /* ! Do not remove EXPORT_START / EXPORT_END ! */
   // $EXPORT_START
   BatchExecuteStatementResponse,

--- a/plugins/s3/types/index.d.ts
+++ b/plugins/s3/types/index.d.ts
@@ -83,6 +83,7 @@ declare module "@aws-lite/client" {
 }
 
 export type {
+  AwsLiteS3,
   /* ! Do not remove EXPORT_START / EXPORT_END ! */
   // $EXPORT_START
   CreateBucketResponse,

--- a/plugins/sns/types/index.d.ts
+++ b/plugins/sns/types/index.d.ts
@@ -24,6 +24,7 @@ declare module "@aws-lite/client" {
 }
 
 export type {
+  AwsLiteSNS,
   /* ! Do not remove EXPORT_START / EXPORT_END ! */
   // $EXPORT_START
   PublishResponse,

--- a/plugins/sqs/types/index.d.ts
+++ b/plugins/sqs/types/index.d.ts
@@ -45,6 +45,7 @@ declare module "@aws-lite/client" {
 }
 
 export type {
+  AwsLiteSQS,
   /* ! Do not remove EXPORT_START / EXPORT_END ! */
   // $EXPORT_START
   SendMessageResponse,

--- a/plugins/ssm/types/index.d.ts
+++ b/plugins/ssm/types/index.d.ts
@@ -59,6 +59,7 @@ declare module "@aws-lite/client" {
 }
 
 export type {
+  AwsLiteSSM,
   /* ! Do not remove EXPORT_START / EXPORT_END ! */
   // $EXPORT_START
   DeleteParameterResponse,

--- a/scripts/generate-plugins/tmpl/_types-tmpl.d.ts
+++ b/scripts/generate-plugins/tmpl/_types-tmpl.d.ts
@@ -17,6 +17,7 @@ declare module "@aws-lite/client" {
 }
 
 export type {
+  AwsLite$PROPERTY,
   /* ! Do not remove EXPORT_START / EXPORT_END ! */
   // $EXPORT_START
   // $EXPORT_END


### PR DESCRIPTION
small change to types to export the main plugin interface type. this will allow more direct importing for consumers like `@architect/functions`