### PR TITLE
Fix pagination when API returns only a subset of possible `token`s

### DIFF
--- a/_changelog.md
+++ b/_changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [0.21.2] 2024-05-08
+
+### Fixed
+
+- Fixed issue where pagination may break if the API that accepts multiple `cursor`s returns only a subset of possible `token`s
+
+---
+
 ## [0.21.1] 2024-04-26
 
 ### Fixed


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
