### PR TITLE
add awsSdkName property to plugin list + types gen

### DIFF
--- a/plugins.mjs
+++ b/plugins.mjs
@@ -26,7 +26,10 @@ const plugins = [
     service: 'rds-data', property: 'RDSData',
     display: 'RDS Data Service', maintainers: [ '@andybee' ],
   },
-  { service: 'route53', property: 'Route53', display: 'Route 53', maintainers },
+  {
+    awsSdkName: 'route-53', // This is the AWS SDK v3 package name
+    service: 'route53', property: 'Route53', display: 'Route 53', maintainers,
+  },
   { service: 's3', property: 'S3', display: 'S3', maintainers },
   { service: 'sns', property: 'SNS', display: 'SNS', maintainers },
   { service: 'sqs', property: 'SQS', display: 'SQS', maintainers },

--- a/plugins/route53/types/index.d.ts
+++ b/plugins/route53/types/index.d.ts
@@ -4,7 +4,7 @@ import {
   ChangeResourceRecordSetsCommandOutput as ChangeResourceRecordSetsResponse,
   ListResourceRecordSetsCommandOutput as ListResourceRecordSetsResponse,
   // $IMPORTS_END
-} from "@aws-sdk/client-route53";
+} from "@aws-sdk/client-route-53";
 
 declare interface AwsLiteRoute53 {
   /* ! Do not remove METHODS_START / METHODS_END ! */

--- a/plugins/route53/types/package.json
+++ b/plugins/route53/types/package.json
@@ -20,7 +20,7 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@aws-sdk/client-route53": "3"
+    "@aws-sdk/client-route-53": "3"
   },
   "scripts": {}
 }


### PR DESCRIPTION
At least in the case of Route 53, the aws-lite service name may differ from AWS's official SDK client. Currently the only way this affects aws-lite is in generating the `*-types` package.

A list of the various client names: https://github.com/aws/aws-sdk-js-v3/tree/main/clients

This change adds a property to the plugins manifest in `plugins.mjs` called `awsSdkName`. When generating the `*-types` package, we use this property if it exists; otherwise, stick with `service`.

The other option is to strictly name the aws-lite plugin the same as AWS SDK v3 client's name.