### PR TITLE
apigatewayv2 add CreateApiMapping

### DIFF
--- a/plugins/apigatewayv2/readme.md
+++ b/plugins/apigatewayv2/readme.md
@@ -32,6 +32,21 @@ npm i -D @aws-lite/apigatewayv2-types
 
 <!-- ! Do not remove METHOD_DOCS_START / METHOD_DOCS_END ! -->
 <!-- METHOD_DOCS_START -->
+### `CreateApiMapping`
+
+[Canonical AWS API doc](https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/domainnames-domainname-apimappings.html#CreateApiMapping)
+
+Properties:
+- **`DomainName` (string) [required]**
+  - The domain name
+- **`ApiId` (string) [required]**
+  - API ID
+- **`ApiMappingKey` (string)**
+  - The API mapping key
+- **`Stage` (string) [required]**
+  - The API stage
+
+
 ### `CreateDeployment`
 
 [Canonical AWS API doc](https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-deployments.html#CreateDeployment)
@@ -161,7 +176,6 @@ Properties:
 > Please help out by [opening a PR](https://github.com/architect/aws-lite#authoring-aws-lite-plugins)!
 
 - [`CreateApi`](https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis.html#CreateApi)
-- [`CreateApiMapping`](https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/domainnames-domainname-apimappings.html#CreateApiMapping)
 - [`CreateAuthorizer`](https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-authorizers.html#CreateAuthorizer)
 - [`CreateIntegration`](https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-integrations.html#CreateIntegration)
 - [`CreateIntegrationResponse`](https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-integrations-integrationid-integrationresponses.html#CreateIntegrationResponse)

--- a/plugins/apigatewayv2/src/incomplete.mjs
+++ b/plugins/apigatewayv2/src/incomplete.mjs
@@ -2,7 +2,6 @@ const disabled = true
 const docRoot = 'https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/'
 export default {
   CreateApi:                   { disabled, awsDoc: docRoot + 'apis.html#CreateApi' },
-  CreateApiMapping:            { disabled, awsDoc: docRoot + 'domainnames-domainname-apimappings.html#CreateApiMapping' },
   CreateAuthorizer:            { disabled, awsDoc: docRoot + 'apis-apiid-authorizers.html#CreateAuthorizer' },
   CreateIntegration:           { disabled, awsDoc: docRoot + 'apis-apiid-integrations.html#CreateIntegration' },
   CreateIntegrationResponse:   { disabled, awsDoc: docRoot + 'apis-apiid-integrations-integrationid-integrationresponses.html#CreateIntegrationResponse' },

--- a/plugins/apigatewayv2/src/index.mjs
+++ b/plugins/apigatewayv2/src/index.mjs
@@ -60,6 +60,24 @@ const CamelToPascalParams = obj => Object.fromEntries(
   ),
 )
 
+const CreateApiMapping = {
+  awsDoc: docRoot + 'domainnames-domainname-apimappings.html#CreateApiMapping',
+  validate: {
+    DomainName,
+    ApiId,
+    ApiMappingKey: { ...str, comment: 'The API mapping key' },
+    Stage: { ...str, required, comment: 'The API stage' },
+  },
+  request: ({ ApiId, ApiMappingKey, Stage, DomainName }) => {
+    return {
+      path: `/v2/domainnames/${DomainName}/apimappings`,
+      method: 'POST',
+      payload: { apiId: ApiId, apiMappingKey: ApiMappingKey, stage: Stage },
+    }
+  },
+  response: defaultResponse,
+}
+
 const CreateDeployment =  {
   awsDoc: docRoot + 'apis-apiid-deployments.html#CreateDeployment',
   validate: {
@@ -218,6 +236,7 @@ export default {
   service,
   property,
   methods: {
+    CreateApiMapping,
     CreateDeployment,
     CreateDomainName,
     DeleteApiMapping,

--- a/plugins/apigatewayv2/types/index.d.ts
+++ b/plugins/apigatewayv2/types/index.d.ts
@@ -1,6 +1,7 @@
 import {
   /* ! Do not remove IMPORTS_START / IMPORTS_END ! */
   // $IMPORTS_START
+  CreateApiMappingCommandOutput as CreateApiMappingResponse,
   CreateDeploymentCommandOutput as CreateDeploymentResponse,
   CreateDomainNameCommandOutput as CreateDomainNameResponse,
   DeleteApiMappingCommandOutput as DeleteApiMappingResponse,
@@ -15,6 +16,12 @@ import {
 declare interface AwsLiteAPIGatewayV2 {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
+  /**
+   * @description
+   * - AWS docs: {@link https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/domainnames-domainname-apimappings.html#CreateApiMapping API Gateway V2: CreateApiMapping}
+   * - aws-lite docs: {@link https://github.com/architect/aws-lite/blob/main/plugins/apigatewayv2/readme.md#CreateApiMapping API Gateway V2: CreateApiMapping}
+   */
+  CreateApiMapping: (input: { DomainName: string, ApiId: string, ApiMappingKey?: string, Stage: string }) => Promise<CreateApiMappingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-deployments.html#CreateDeployment API Gateway V2: CreateDeployment}
@@ -76,6 +83,7 @@ export type {
   AwsLiteAPIGatewayV2,
   /* ! Do not remove EXPORT_START / EXPORT_END ! */
   // $EXPORT_START
+  CreateApiMappingResponse,
   CreateDeploymentResponse,
   CreateDomainNameResponse,
   DeleteApiMappingResponse,


### PR DESCRIPTION
Some reference:

https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/domainnames-domainname-apimappings.html
https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/apigatewayv2/command/CreateApiMappingCommand/

I haven't updated a plugin in a bit, let me know if I missed anything. Thanks!