### PR TITLE
fix(types): expose common method arguments like `region` and `paginate`

### DIFF
--- a/plugins/acm/types/index.d.ts
+++ b/plugins/acm/types/index.d.ts
@@ -8,6 +8,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-acm";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteACM {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -16,25 +18,25 @@ declare interface AwsLiteACM {
    * - AWS docs: {@link https://docs.aws.amazon.com/acm/latest/APIReference/API_DeleteCertificate.html ACM: DeleteCertificate}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/acm/readme.md#DeleteCertificate ACM: DeleteCertificate}
    */
-  DeleteCertificate: (input: { CertificateArn: string }) => Promise<DeleteCertificateResponse>
+  DeleteCertificate: (input: AwsLiteMethodOptions & { CertificateArn: string }) => Promise<DeleteCertificateResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/acm/latest/APIReference/API_DescribeCertificate.html ACM: DescribeCertificate}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/acm/readme.md#DescribeCertificate ACM: DescribeCertificate}
    */
-  DescribeCertificate: (input: { CertificateArn: string }) => Promise<DescribeCertificateResponse>
+  DescribeCertificate: (input: AwsLiteMethodOptions & { CertificateArn: string }) => Promise<DescribeCertificateResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/acm/latest/APIReference/API_ListCertificates.html ACM: ListCertificates}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/acm/readme.md#ListCertificates ACM: ListCertificates}
    */
-  ListCertificates: (input: { CertificateStatuses?: any[], Includes?: Record<string, any>, MaxItems?: number, NextToken?: string, SortBy?: string, SortOrder?: string, paginate?: boolean | string }) => Promise<ListCertificatesResponse>
+  ListCertificates: (input: AwsLiteMethodOptions & { CertificateStatuses?: any[], Includes?: Record<string, any>, MaxItems?: number, NextToken?: string, SortBy?: string, SortOrder?: string, paginate?: boolean | string }) => Promise<ListCertificatesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/acm/latest/APIReference/API_RequestCertificate.html ACM: RequestCertificate}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/acm/readme.md#RequestCertificate ACM: RequestCertificate}
    */
-  RequestCertificate: (input: { DomainName: string, CertificateAuthorityArn?: string, DomainValidationOptions?: any[], IdempotencyToken?: string, KeyAlgorithm?: string, Options?: Record<string, any>, SubjectAlternativeNames?: any[], Tags?: any[], ValidationMethod?: string }) => Promise<RequestCertificateResponse>
+  RequestCertificate: (input: AwsLiteMethodOptions & { DomainName: string, CertificateAuthorityArn?: string, DomainValidationOptions?: any[], IdempotencyToken?: string, KeyAlgorithm?: string, Options?: Record<string, any>, SubjectAlternativeNames?: any[], Tags?: any[], ValidationMethod?: string }) => Promise<RequestCertificateResponse>
   // $METHODS_END
 }
 

--- a/plugins/apigatewaymanagementapi/types/index.d.ts
+++ b/plugins/apigatewaymanagementapi/types/index.d.ts
@@ -7,6 +7,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-apigatewaymanagementapi";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteApiGatewayManagementApi {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -15,19 +17,19 @@ declare interface AwsLiteApiGatewayManagementApi {
    * - AWS docs: {@link https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-how-to-call-websocket-api-connections.html API Gateway WebSocket Management API: PostToConnection}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/apigatewaymanagementapi/readme.md#PostToConnection API Gateway WebSocket Management API: PostToConnection}
    */
-  PostToConnection: (input: { ConnectionId: string, ApiUrl?: string, ApiId?: string, Stage?: string, Data?: string | Record<string, any> }) => Promise<PostToConnectionResponse>
+  PostToConnection: (input: AwsLiteMethodOptions & { ConnectionId: string, ApiUrl?: string, ApiId?: string, Stage?: string, Data?: string | Record<string, any> }) => Promise<PostToConnectionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-how-to-call-websocket-api-connections.html API Gateway WebSocket Management API: DeleteConnection}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/apigatewaymanagementapi/readme.md#DeleteConnection API Gateway WebSocket Management API: DeleteConnection}
    */
-  DeleteConnection: (input: { ConnectionId: string, ApiUrl?: string, ApiId?: string, Stage?: string }) => Promise<DeleteConnectionResponse>
+  DeleteConnection: (input: AwsLiteMethodOptions & { ConnectionId: string, ApiUrl?: string, ApiId?: string, Stage?: string }) => Promise<DeleteConnectionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-how-to-call-websocket-api-connections.html API Gateway WebSocket Management API: GetConnection}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/apigatewaymanagementapi/readme.md#GetConnection API Gateway WebSocket Management API: GetConnection}
    */
-  GetConnection: (input: { ConnectionId: string, ApiUrl?: string, ApiId?: string, Stage?: string }) => Promise<GetConnectionResponse>
+  GetConnection: (input: AwsLiteMethodOptions & { ConnectionId: string, ApiUrl?: string, ApiId?: string, Stage?: string }) => Promise<GetConnectionResponse>
   // $METHODS_END
 }
 

--- a/plugins/apigatewayv2/types/index.d.ts
+++ b/plugins/apigatewayv2/types/index.d.ts
@@ -13,6 +13,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-apigatewayv2";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteAPIGatewayV2 {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -21,55 +23,55 @@ declare interface AwsLiteAPIGatewayV2 {
    * - AWS docs: {@link https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/domainnames-domainname-apimappings.html#CreateApiMapping API Gateway V2: CreateApiMapping}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/apigatewayv2/readme.md#CreateApiMapping API Gateway V2: CreateApiMapping}
    */
-  CreateApiMapping: (input: { DomainName: string, ApiId: string, ApiMappingKey?: string, Stage: string }) => Promise<CreateApiMappingResponse>
+  CreateApiMapping: (input: AwsLiteMethodOptions & { DomainName: string, ApiId: string, ApiMappingKey?: string, Stage: string }) => Promise<CreateApiMappingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-deployments.html#CreateDeployment API Gateway V2: CreateDeployment}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/apigatewayv2/readme.md#CreateDeployment API Gateway V2: CreateDeployment}
    */
-  CreateDeployment: (input: { ApiId: string, Description?: string, StageName?: string }) => Promise<CreateDeploymentResponse>
+  CreateDeployment: (input: AwsLiteMethodOptions & { ApiId: string, Description?: string, StageName?: string }) => Promise<CreateDeploymentResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/domainnames.html#CreateDomainName API Gateway V2: CreateDomainName}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/apigatewayv2/readme.md#CreateDomainName API Gateway V2: CreateDomainName}
    */
-  CreateDomainName: (input: { DomainName: string, DomainNameConfigurations?: any[], MutualTlsAuthentication?: Record<string, any>, Tags?: Record<string, any> }) => Promise<CreateDomainNameResponse>
+  CreateDomainName: (input: AwsLiteMethodOptions & { DomainName: string, DomainNameConfigurations?: any[], MutualTlsAuthentication?: Record<string, any>, Tags?: Record<string, any> }) => Promise<CreateDomainNameResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/domainnames-domainname-apimappings-apimappingid.html#DeleteApiMapping API Gateway V2: DeleteApiMapping}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/apigatewayv2/readme.md#DeleteApiMapping API Gateway V2: DeleteApiMapping}
    */
-  DeleteApiMapping: (input: { ApiMappingId: string, DomainName: string }) => Promise<DeleteApiMappingResponse>
+  DeleteApiMapping: (input: AwsLiteMethodOptions & { ApiMappingId: string, DomainName: string }) => Promise<DeleteApiMappingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/domainnames-domainname.html#DeleteDomainName API Gateway V2: DeleteDomainName}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/apigatewayv2/readme.md#DeleteDomainName API Gateway V2: DeleteDomainName}
    */
-  DeleteDomainName: (input: { DomainName: string }) => Promise<DeleteDomainNameResponse>
+  DeleteDomainName: (input: AwsLiteMethodOptions & { DomainName: string }) => Promise<DeleteDomainNameResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/domainnames-domainname-apimappings.html#GetApiMappings API Gateway V2: GetApiMappings}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/apigatewayv2/readme.md#GetApiMappings API Gateway V2: GetApiMappings}
    */
-  GetApiMappings: (input: { DomainName: string, MaxResults?: number, NextToken?: string, paginate?: boolean | string }) => Promise<GetApiMappingsResponse>
+  GetApiMappings: (input: AwsLiteMethodOptions & { DomainName: string, MaxResults?: number, NextToken?: string, paginate?: boolean | string }) => Promise<GetApiMappingsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-deployments-deploymentid.html#GetDeployment API Gateway V2: GetDeployment}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/apigatewayv2/readme.md#GetDeployment API Gateway V2: GetDeployment}
    */
-  GetDeployment: (input: { ApiId: string, NextToken?: string, MaxResults?: number }) => Promise<GetDeploymentResponse>
+  GetDeployment: (input: AwsLiteMethodOptions & { ApiId: string, NextToken?: string, MaxResults?: number }) => Promise<GetDeploymentResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-deployments.html#GetDeployments API Gateway V2: GetDeployments}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/apigatewayv2/readme.md#GetDeployments API Gateway V2: GetDeployments}
    */
-  GetDeployments: (input: { ApiId: string, NextToken?: string, MaxResults?: number, paginate?: boolean | string }) => Promise<GetDeploymentsResponse>
+  GetDeployments: (input: AwsLiteMethodOptions & { ApiId: string, NextToken?: string, MaxResults?: number, paginate?: boolean | string }) => Promise<GetDeploymentsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-stages-stagename.html#UpdateStage API Gateway V2: UpdateStage}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/apigatewayv2/readme.md#UpdateStage API Gateway V2: UpdateStage}
    */
-  UpdateStage: (input: { ApiId: string, StageName: string, AccessLogSettings?: Record<string, any>, AutoDeploy?: boolean, ClientCertificateId?: string, DefaultRouteSettings?: Record<string, any>, DeploymentId?: string, Description?: string, RouteSettings?: Record<string, any>, StageVariables?: Record<string, any> }) => Promise<UpdateStageResponse>
+  UpdateStage: (input: AwsLiteMethodOptions & { ApiId: string, StageName: string, AccessLogSettings?: Record<string, any>, AutoDeploy?: boolean, ClientCertificateId?: string, DefaultRouteSettings?: Record<string, any>, DeploymentId?: string, Description?: string, RouteSettings?: Record<string, any>, StageVariables?: Record<string, any> }) => Promise<UpdateStageResponse>
   // $METHODS_END
 }
 

--- a/plugins/cloudformation/types/index.d.ts
+++ b/plugins/cloudformation/types/index.d.ts
@@ -11,6 +11,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-cloudformation";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteCloudFormation {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -19,43 +21,43 @@ declare interface AwsLiteCloudFormation {
    * - AWS docs: {@link https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html CloudFormation: CreateStack}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudformation/readme.md#CreateStack CloudFormation: CreateStack}
    */
-  CreateStack: (input: { StackName: string, Capabilities?: any[], ClientRequestToken?: string, DisableRollback?: boolean, EnableTerminationProtection?: boolean, NotificationARNs?: any[], OnFailure?: string, Parameters?: any[], ResourceTypes?: any[], RetainExceptOnCreate?: boolean, RoleARN?: string, RollbackConfiguration?: Record<string, any>, StackPolicyBody?: string | Record<string, any>, StackPolicyURL?: string, Tags?: any[], TemplateBody?: string | Record<string, any>, TemplateURL?: string, TimeoutInMinutes?: number }) => Promise<CreateStackResponse>
+  CreateStack: (input: AwsLiteMethodOptions & { StackName: string, Capabilities?: any[], ClientRequestToken?: string, DisableRollback?: boolean, EnableTerminationProtection?: boolean, NotificationARNs?: any[], OnFailure?: string, Parameters?: any[], ResourceTypes?: any[], RetainExceptOnCreate?: boolean, RoleARN?: string, RollbackConfiguration?: Record<string, any>, StackPolicyBody?: string | Record<string, any>, StackPolicyURL?: string, Tags?: any[], TemplateBody?: string | Record<string, any>, TemplateURL?: string, TimeoutInMinutes?: number }) => Promise<CreateStackResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DeleteStack.html CloudFormation: DeleteStack}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudformation/readme.md#DeleteStack CloudFormation: DeleteStack}
    */
-  DeleteStack: (input: { StackName: string, ClientRequestToken?: string, RetainResources?: any[], RoleARN?: string }) => Promise<DeleteStackResponse>
+  DeleteStack: (input: AwsLiteMethodOptions & { StackName: string, ClientRequestToken?: string, RetainResources?: any[], RoleARN?: string }) => Promise<DeleteStackResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DescribeStackResources.html CloudFormation: DescribeStackResources}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudformation/readme.md#DescribeStackResources CloudFormation: DescribeStackResources}
    */
-  DescribeStackResources: (input: { StackName?: string, LogicalResourceId?: string, PhysicalResourceId?: string }) => Promise<DescribeStackResourcesResponse>
+  DescribeStackResources: (input: AwsLiteMethodOptions & { StackName?: string, LogicalResourceId?: string, PhysicalResourceId?: string }) => Promise<DescribeStackResourcesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DescribeStacks.html CloudFormation: DescribeStacks}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudformation/readme.md#DescribeStacks CloudFormation: DescribeStacks}
    */
-  DescribeStacks: (input: { StackName?: string, NextToken?: string, paginate?: boolean | string }) => Promise<DescribeStacksResponse>
+  DescribeStacks: (input: AwsLiteMethodOptions & { StackName?: string, NextToken?: string, paginate?: boolean | string }) => Promise<DescribeStacksResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_ListStackResources.html CloudFormation: ListStackResources}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudformation/readme.md#ListStackResources CloudFormation: ListStackResources}
    */
-  ListStackResources: (input: { StackName: string, NextToken?: string, paginate?: boolean | string }) => Promise<ListStackResourcesResponse>
+  ListStackResources: (input: AwsLiteMethodOptions & { StackName: string, NextToken?: string, paginate?: boolean | string }) => Promise<ListStackResourcesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStack.html CloudFormation: UpdateStack}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudformation/readme.md#UpdateStack CloudFormation: UpdateStack}
    */
-  UpdateStack: (input: { StackName: string, Capabilities?: any[], ClientRequestToken?: string, DisableRollback?: boolean, NotificationARNs?: any[], Parameters?: any[], ResourceTypes?: any[], RetainExceptOnCreate?: boolean, RoleARN?: string, RollbackConfiguration?: Record<string, any>, StackPolicyBody?: string | Record<string, any>, StackPolicyURL?: string, Tags?: any[], TemplateBody?: string | Record<string, any>, TemplateURL?: string }) => Promise<UpdateStackResponse>
+  UpdateStack: (input: AwsLiteMethodOptions & { StackName: string, Capabilities?: any[], ClientRequestToken?: string, DisableRollback?: boolean, NotificationARNs?: any[], Parameters?: any[], ResourceTypes?: any[], RetainExceptOnCreate?: boolean, RoleARN?: string, RollbackConfiguration?: Record<string, any>, StackPolicyBody?: string | Record<string, any>, StackPolicyURL?: string, Tags?: any[], TemplateBody?: string | Record<string, any>, TemplateURL?: string }) => Promise<UpdateStackResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateTerminationProtection.html CloudFormation: UpdateTerminationProtection}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudformation/readme.md#UpdateTerminationProtection CloudFormation: UpdateTerminationProtection}
    */
-  UpdateTerminationProtection: (input: { StackName: string, EnableTerminationProtection: boolean }) => Promise<UpdateTerminationProtectionResponse>
+  UpdateTerminationProtection: (input: AwsLiteMethodOptions & { StackName: string, EnableTerminationProtection: boolean }) => Promise<UpdateTerminationProtectionResponse>
   // $METHODS_END
 }
 

--- a/plugins/cloudfront/types/index.d.ts
+++ b/plugins/cloudfront/types/index.d.ts
@@ -11,6 +11,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-cloudfront";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteCloudFront {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -19,43 +21,43 @@ declare interface AwsLiteCloudFront {
    * - AWS docs: {@link https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateDistribution.html CloudFront: CreateDistribution}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudfront/readme.md#CreateDistribution CloudFront: CreateDistribution}
    */
-  CreateDistribution: (input: { DistributionConfig: Record<string, any> }) => Promise<CreateDistributionResponse>
+  CreateDistribution: (input: AwsLiteMethodOptions & { DistributionConfig: Record<string, any> }) => Promise<CreateDistributionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateInvalidation.html CloudFront: CreateInvalidation}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudfront/readme.md#CreateInvalidation CloudFront: CreateInvalidation}
    */
-  CreateInvalidation: (input: { Id: string, InvalidationBatch?: string | any[], CallerReference: string }) => Promise<CreateInvalidationResponse>
+  CreateInvalidation: (input: AwsLiteMethodOptions & { Id: string, InvalidationBatch?: string | any[], CallerReference: string }) => Promise<CreateInvalidationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DeleteDistribution.html CloudFront: DeleteDistribution}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudfront/readme.md#DeleteDistribution CloudFront: DeleteDistribution}
    */
-  DeleteDistribution: (input: { Id: string, IfMatch?: string }) => Promise<DeleteDistributionResponse>
+  DeleteDistribution: (input: AwsLiteMethodOptions & { Id: string, IfMatch?: string }) => Promise<DeleteDistributionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetDistribution.html CloudFront: GetDistribution}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudfront/readme.md#GetDistribution CloudFront: GetDistribution}
    */
-  GetDistribution: (input: { Id: string }) => Promise<GetDistributionResponse>
+  GetDistribution: (input: AwsLiteMethodOptions & { Id: string }) => Promise<GetDistributionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetDistributionConfig.html CloudFront: GetDistributionConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudfront/readme.md#GetDistributionConfig CloudFront: GetDistributionConfig}
    */
-  GetDistributionConfig: (input: { Id: string }) => Promise<GetDistributionConfigResponse>
+  GetDistributionConfig: (input: AwsLiteMethodOptions & { Id: string }) => Promise<GetDistributionConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListDistributions.html CloudFront: ListDistributions}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudfront/readme.md#ListDistributions CloudFront: ListDistributions}
    */
-  ListDistributions: (input: { Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListDistributionsResponse>
+  ListDistributions: (input: AwsLiteMethodOptions & { Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListDistributionsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdateDistribution.html CloudFront: UpdateDistribution}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudfront/readme.md#UpdateDistribution CloudFront: UpdateDistribution}
    */
-  UpdateDistribution: (input: { DistributionConfig: Record<string, any>, Id: string, IfMatch: string }) => Promise<UpdateDistributionResponse>
+  UpdateDistribution: (input: AwsLiteMethodOptions & { DistributionConfig: Record<string, any>, Id: string, IfMatch: string }) => Promise<UpdateDistributionResponse>
   // $METHODS_END
 }
 

--- a/plugins/cloudwatch-logs/types/index.d.ts
+++ b/plugins/cloudwatch-logs/types/index.d.ts
@@ -11,6 +11,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-cloudwatch-logs";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteCloudWatchLogs {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -19,43 +21,43 @@ declare interface AwsLiteCloudWatchLogs {
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DeleteLogGroup.html CloudWatch Logs: DeleteLogGroup}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudwatch-logs/readme.md#DeleteLogGroup CloudWatch Logs: DeleteLogGroup}
    */
-  DeleteLogGroup: (input: { logGroupName: string }) => Promise<DeleteLogGroupResponse>
+  DeleteLogGroup: (input: AwsLiteMethodOptions & { logGroupName: string }) => Promise<DeleteLogGroupResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DeleteLogStream.html CloudWatch Logs: DeleteLogStream}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudwatch-logs/readme.md#DeleteLogStream CloudWatch Logs: DeleteLogStream}
    */
-  DeleteLogStream: (input: { logGroupName: string, logStreamName: string }) => Promise<DeleteLogStreamResponse>
+  DeleteLogStream: (input: AwsLiteMethodOptions & { logGroupName: string, logStreamName: string }) => Promise<DeleteLogStreamResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogGroups.html CloudWatch Logs: DescribeLogGroups}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudwatch-logs/readme.md#DescribeLogGroups CloudWatch Logs: DescribeLogGroups}
    */
-  DescribeLogGroups: (input: { accountIdentifiers?: any[], logGroupNamePrefix?: string, logGroupNamePattern?: string, nextToken?: string, limit?: number, includeLinkedAccounts?: boolean, logGroupClass?: string, paginate?: boolean | string }) => Promise<DescribeLogGroupsResponse>
+  DescribeLogGroups: (input: AwsLiteMethodOptions & { accountIdentifiers?: any[], logGroupNamePrefix?: string, logGroupNamePattern?: string, nextToken?: string, limit?: number, includeLinkedAccounts?: boolean, logGroupClass?: string, paginate?: boolean | string }) => Promise<DescribeLogGroupsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogStreams.html CloudWatch Logs: DescribeLogStreams}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudwatch-logs/readme.md#DescribeLogStreams CloudWatch Logs: DescribeLogStreams}
    */
-  DescribeLogStreams: (input: { descending?: boolean, limit?: number, logGroupIdentifier?: string, logGroupName?: string, logStreamNamePrefix?: string, nextToken?: string, orderBy?: string, paginate?: boolean | string }) => Promise<DescribeLogStreamsResponse>
+  DescribeLogStreams: (input: AwsLiteMethodOptions & { descending?: boolean, limit?: number, logGroupIdentifier?: string, logGroupName?: string, logStreamNamePrefix?: string, nextToken?: string, orderBy?: string, paginate?: boolean | string }) => Promise<DescribeLogStreamsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogEvents.html CloudWatch Logs: GetLogEvents}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudwatch-logs/readme.md#GetLogEvents CloudWatch Logs: GetLogEvents}
    */
-  GetLogEvents: (input: { endTime?: number, limit?: number, logGroupIdentifier?: string, logGroupName?: string, logStreamName: string, nextToken?: string, startFromHead?: boolean, startTime?: number, unmask?: boolean, paginate?: boolean | string }) => Promise<GetLogEventsResponse>
+  GetLogEvents: (input: AwsLiteMethodOptions & { endTime?: number, limit?: number, logGroupIdentifier?: string, logGroupName?: string, logStreamName: string, nextToken?: string, startFromHead?: boolean, startTime?: number, unmask?: boolean, paginate?: boolean | string }) => Promise<GetLogEventsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetQueryResults.html CloudWatch Logs: GetQueryResults}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudwatch-logs/readme.md#GetQueryResults CloudWatch Logs: GetQueryResults}
    */
-  GetQueryResults: (input: { queryId?: string }) => Promise<GetQueryResultsResponse>
+  GetQueryResults: (input: AwsLiteMethodOptions & { queryId?: string }) => Promise<GetQueryResultsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_StartQuery.html CloudWatch Logs: StartQuery}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/cloudwatch-logs/readme.md#StartQuery CloudWatch Logs: StartQuery}
    */
-  StartQuery: (input: { endTime?: number, limit?: number, logGroupIdentifiers?: any[], logGroupName?: string, logGroupNames?: any[], query?: string, startTime?: number }) => Promise<StartQueryResponse>
+  StartQuery: (input: AwsLiteMethodOptions & { endTime?: number, limit?: number, logGroupIdentifiers?: any[], logGroupName?: string, logGroupNames?: any[], query?: string, startTime?: number }) => Promise<StartQueryResponse>
   // $METHODS_END
 }
 

--- a/plugins/dynamodb/types/index.d.ts
+++ b/plugins/dynamodb/types/index.d.ts
@@ -57,6 +57,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-dynamodb";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteDynamoDB {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -65,311 +67,311 @@ declare interface AwsLiteDynamoDB {
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchExecuteStatement.html DynamoDB: BatchExecuteStatement}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#BatchExecuteStatement DynamoDB: BatchExecuteStatement}
    */
-  BatchExecuteStatement: (input: { Statements: any[], ReturnConsumedCapacity?: string }) => Promise<BatchExecuteStatementResponse>
+  BatchExecuteStatement: (input: AwsLiteMethodOptions & { Statements: any[], ReturnConsumedCapacity?: string }) => Promise<BatchExecuteStatementResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html DynamoDB: BatchGetItem}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#BatchGetItem DynamoDB: BatchGetItem}
    */
-  BatchGetItem: (input: { RequestItems: Record<string, any>, ReturnConsumedCapacity?: string }) => Promise<BatchGetItemResponse>
+  BatchGetItem: (input: AwsLiteMethodOptions & { RequestItems: Record<string, any>, ReturnConsumedCapacity?: string }) => Promise<BatchGetItemResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html DynamoDB: BatchWriteItem}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#BatchWriteItem DynamoDB: BatchWriteItem}
    */
-  BatchWriteItem: (input: { RequestItems: Record<string, any>, ReturnConsumedCapacity?: string, ReturnItemCollectionMetrics?: string }) => Promise<BatchWriteItemResponse>
+  BatchWriteItem: (input: AwsLiteMethodOptions & { RequestItems: Record<string, any>, ReturnConsumedCapacity?: string, ReturnItemCollectionMetrics?: string }) => Promise<BatchWriteItemResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateBackup.html DynamoDB: CreateBackup}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#CreateBackup DynamoDB: CreateBackup}
    */
-  CreateBackup: (input: { TableName: string, BackupName: string }) => Promise<CreateBackupResponse>
+  CreateBackup: (input: AwsLiteMethodOptions & { TableName: string, BackupName: string }) => Promise<CreateBackupResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateGlobalTable.html DynamoDB: CreateGlobalTable}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#CreateGlobalTable DynamoDB: CreateGlobalTable}
    */
-  CreateGlobalTable: (input: { GlobalTableName: string, ReplicationGroup: any[] }) => Promise<CreateGlobalTableResponse>
+  CreateGlobalTable: (input: AwsLiteMethodOptions & { GlobalTableName: string, ReplicationGroup: any[] }) => Promise<CreateGlobalTableResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html DynamoDB: CreateTable}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#CreateTable DynamoDB: CreateTable}
    */
-  CreateTable: (input: { TableName: string, AttributeDefinitions: any[], KeySchema: any[], BillingMode?: string, DeletionProtectionEnabled?: boolean, GlobalSecondaryIndexes?: any[], LocalSecondaryIndexes?: any[], ProvisionedThroughput?: Record<string, any>, SSESpecification?: Record<string, any>, StreamSpecification?: Record<string, any>, TableClass?: string, Tags?: any[] }) => Promise<CreateTableResponse>
+  CreateTable: (input: AwsLiteMethodOptions & { TableName: string, AttributeDefinitions: any[], KeySchema: any[], BillingMode?: string, DeletionProtectionEnabled?: boolean, GlobalSecondaryIndexes?: any[], LocalSecondaryIndexes?: any[], ProvisionedThroughput?: Record<string, any>, SSESpecification?: Record<string, any>, StreamSpecification?: Record<string, any>, TableClass?: string, Tags?: any[] }) => Promise<CreateTableResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteBackup.html DynamoDB: DeleteBackup}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DeleteBackup DynamoDB: DeleteBackup}
    */
-  DeleteBackup: (input: { BackupArn: string }) => Promise<DeleteBackupResponse>
+  DeleteBackup: (input: AwsLiteMethodOptions & { BackupArn: string }) => Promise<DeleteBackupResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteItem.html DynamoDB: DeleteItem}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DeleteItem DynamoDB: DeleteItem}
    */
-  DeleteItem: (input: { TableName: string, Key: Record<string, any>, ConditionalOperator?: string, ConditionExpression?: string, Expected?: Record<string, any>, ExpressionAttributeNames?: Record<string, any>, ExpressionAttributeValues?: Record<string, any>, ReturnConsumedCapacity?: string, ReturnItemCollectionMetrics?: string, ReturnValues?: string, ReturnValuesOnConditionCheckFailure?: string }) => Promise<DeleteItemResponse>
+  DeleteItem: (input: AwsLiteMethodOptions & { TableName: string, Key: Record<string, any>, ConditionalOperator?: string, ConditionExpression?: string, Expected?: Record<string, any>, ExpressionAttributeNames?: Record<string, any>, ExpressionAttributeValues?: Record<string, any>, ReturnConsumedCapacity?: string, ReturnItemCollectionMetrics?: string, ReturnValues?: string, ReturnValuesOnConditionCheckFailure?: string }) => Promise<DeleteItemResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteTable.html DynamoDB: DeleteTable}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DeleteTable DynamoDB: DeleteTable}
    */
-  DeleteTable: (input: { TableName: string }) => Promise<DeleteTableResponse>
+  DeleteTable: (input: AwsLiteMethodOptions & { TableName: string }) => Promise<DeleteTableResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeBackup.html DynamoDB: DescribeBackup}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DescribeBackup DynamoDB: DescribeBackup}
    */
-  DescribeBackup: (input: { BackupArn: string }) => Promise<DescribeBackupResponse>
+  DescribeBackup: (input: AwsLiteMethodOptions & { BackupArn: string }) => Promise<DescribeBackupResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeContinuousBackups.html DynamoDB: DescribeContinuousBackups}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DescribeContinuousBackups DynamoDB: DescribeContinuousBackups}
    */
-  DescribeContinuousBackups: (input: { TableName: string }) => Promise<DescribeContinuousBackupsResponse>
+  DescribeContinuousBackups: (input: AwsLiteMethodOptions & { TableName: string }) => Promise<DescribeContinuousBackupsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeContributorInsights.html DynamoDB: DescribeContributorInsights}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DescribeContributorInsights DynamoDB: DescribeContributorInsights}
    */
-  DescribeContributorInsights: (input: { TableName: string, IndexName?: string }) => Promise<DescribeContributorInsightsResponse>
+  DescribeContributorInsights: (input: AwsLiteMethodOptions & { TableName: string, IndexName?: string }) => Promise<DescribeContributorInsightsResponse>
   /** @description aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DescribeEndpoints DynamoDB: DescribeEndpoints} */
-  DescribeEndpoints: () => Promise<DescribeEndpointsResponse>
+  DescribeEndpoints: (input?: AwsLiteMethodOptions) => Promise<DescribeEndpointsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeExport.html DynamoDB: DescribeExport}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DescribeExport DynamoDB: DescribeExport}
    */
-  DescribeExport: (input: { ExportArn: string }) => Promise<DescribeExportResponse>
+  DescribeExport: (input: AwsLiteMethodOptions & { ExportArn: string }) => Promise<DescribeExportResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeGlobalTable.html DynamoDB: DescribeGlobalTable}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DescribeGlobalTable DynamoDB: DescribeGlobalTable}
    */
-  DescribeGlobalTable: (input: { GlobalTableName: string }) => Promise<DescribeGlobalTableResponse>
+  DescribeGlobalTable: (input: AwsLiteMethodOptions & { GlobalTableName: string }) => Promise<DescribeGlobalTableResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeGlobalTableSettings.html DynamoDB: DescribeGlobalTableSettings}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DescribeGlobalTableSettings DynamoDB: DescribeGlobalTableSettings}
    */
-  DescribeGlobalTableSettings: (input: { GlobalTableName: string }) => Promise<DescribeGlobalTableSettingsResponse>
+  DescribeGlobalTableSettings: (input: AwsLiteMethodOptions & { GlobalTableName: string }) => Promise<DescribeGlobalTableSettingsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeImport.html DynamoDB: DescribeImport}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DescribeImport DynamoDB: DescribeImport}
    */
-  DescribeImport: (input: { ImportArn: string }) => Promise<DescribeImportResponse>
+  DescribeImport: (input: AwsLiteMethodOptions & { ImportArn: string }) => Promise<DescribeImportResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeKinesisStreamingDestination.html DynamoDB: DescribeKinesisStreamingDestination}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DescribeKinesisStreamingDestination DynamoDB: DescribeKinesisStreamingDestination}
    */
-  DescribeKinesisStreamingDestination: (input: { TableName: string }) => Promise<DescribeKinesisStreamingDestinationResponse>
+  DescribeKinesisStreamingDestination: (input: AwsLiteMethodOptions & { TableName: string }) => Promise<DescribeKinesisStreamingDestinationResponse>
   /** @description aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DescribeLimits DynamoDB: DescribeLimits} */
-  DescribeLimits: () => Promise<DescribeLimitsResponse>
+  DescribeLimits: (input?: AwsLiteMethodOptions) => Promise<DescribeLimitsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeTable.html DynamoDB: DescribeTable}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DescribeTable DynamoDB: DescribeTable}
    */
-  DescribeTable: (input: { TableName: string }) => Promise<DescribeTableResponse>
+  DescribeTable: (input: AwsLiteMethodOptions & { TableName: string }) => Promise<DescribeTableResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeTableReplicaAutoScaling.html DynamoDB: DescribeTableReplicaAutoScaling}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DescribeTableReplicaAutoScaling DynamoDB: DescribeTableReplicaAutoScaling}
    */
-  DescribeTableReplicaAutoScaling: (input: { TableName: string }) => Promise<DescribeTableReplicaAutoScalingResponse>
+  DescribeTableReplicaAutoScaling: (input: AwsLiteMethodOptions & { TableName: string }) => Promise<DescribeTableReplicaAutoScalingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeTimeToLive.html DynamoDB: DescribeTimeToLive}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DescribeTimeToLive DynamoDB: DescribeTimeToLive}
    */
-  DescribeTimeToLive: (input: { TableName: string }) => Promise<DescribeTimeToLiveResponse>
+  DescribeTimeToLive: (input: AwsLiteMethodOptions & { TableName: string }) => Promise<DescribeTimeToLiveResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DisableKinesisStreamingDestination.html DynamoDB: DisableKinesisStreamingDestination}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#DisableKinesisStreamingDestination DynamoDB: DisableKinesisStreamingDestination}
    */
-  DisableKinesisStreamingDestination: (input: { TableName: string, StreamArn: string }) => Promise<DisableKinesisStreamingDestinationResponse>
+  DisableKinesisStreamingDestination: (input: AwsLiteMethodOptions & { TableName: string, StreamArn: string }) => Promise<DisableKinesisStreamingDestinationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_EnableKinesisStreamingDestination.html DynamoDB: EnableKinesisStreamingDestination}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#EnableKinesisStreamingDestination DynamoDB: EnableKinesisStreamingDestination}
    */
-  EnableKinesisStreamingDestination: (input: { TableName: string, StreamArn: string }) => Promise<EnableKinesisStreamingDestinationResponse>
+  EnableKinesisStreamingDestination: (input: AwsLiteMethodOptions & { TableName: string, StreamArn: string }) => Promise<EnableKinesisStreamingDestinationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html DynamoDB: ExecuteStatement}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#ExecuteStatement DynamoDB: ExecuteStatement}
    */
-  ExecuteStatement: (input: { TableName: string, Statement: string, ConsistentRead?: boolean, Limit?: number, NextToken?: string, Parameters?: any[], ReturnConsumedCapacity?: string, ReturnValuesOnConditionCheckFailure?: string }) => Promise<ExecuteStatementResponse>
+  ExecuteStatement: (input: AwsLiteMethodOptions & { TableName: string, Statement: string, ConsistentRead?: boolean, Limit?: number, NextToken?: string, Parameters?: any[], ReturnConsumedCapacity?: string, ReturnValuesOnConditionCheckFailure?: string }) => Promise<ExecuteStatementResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteTransaction.html DynamoDB: ExecuteTransaction}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#ExecuteTransaction DynamoDB: ExecuteTransaction}
    */
-  ExecuteTransaction: (input: { TableName: string, TransactStatements: any[], ClientRequestToken?: string, ReturnConsumedCapacity?: string }) => Promise<ExecuteTransactionResponse>
+  ExecuteTransaction: (input: AwsLiteMethodOptions & { TableName: string, TransactStatements: any[], ClientRequestToken?: string, ReturnConsumedCapacity?: string }) => Promise<ExecuteTransactionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExportTableToPointInTime.html DynamoDB: ExportTableToPointInTime}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#ExportTableToPointInTime DynamoDB: ExportTableToPointInTime}
    */
-  ExportTableToPointInTime: (input: { S3Bucket: string, TableArn: string, ClientToken?: string, ExportFormat?: string, ExportTime?: number, S3BucketOwner?: string, S3Prefix?: string, S3SseAlgorithm?: string, S3SseKmsKeyId?: string }) => Promise<ExportTableToPointInTimeResponse>
+  ExportTableToPointInTime: (input: AwsLiteMethodOptions & { S3Bucket: string, TableArn: string, ClientToken?: string, ExportFormat?: string, ExportTime?: number, S3BucketOwner?: string, S3Prefix?: string, S3SseAlgorithm?: string, S3SseKmsKeyId?: string }) => Promise<ExportTableToPointInTimeResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_GetItem.html DynamoDB: GetItem}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#GetItem DynamoDB: GetItem}
    */
-  GetItem: (input: { TableName: string, Key: Record<string, any>, AttributesToGet?: any[], ConsistentRead?: boolean, ExpressionAttributeNames?: Record<string, any>, ProjectionExpression?: string, ReturnConsumedCapacity?: string }) => Promise<GetItemResponse>
+  GetItem: (input: AwsLiteMethodOptions & { TableName: string, Key: Record<string, any>, AttributesToGet?: any[], ConsistentRead?: boolean, ExpressionAttributeNames?: Record<string, any>, ProjectionExpression?: string, ReturnConsumedCapacity?: string }) => Promise<GetItemResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ImportTable.html DynamoDB: ImportTable}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#ImportTable DynamoDB: ImportTable}
    */
-  ImportTable: (input: { InputFormat: string, S3BucketSource: Record<string, any>, TableCreationParameters: Record<string, any>, ClientToken?: string, InputCompressionType?: string, InputFormatOptions?: Record<string, any> }) => Promise<ImportTableResponse>
+  ImportTable: (input: AwsLiteMethodOptions & { InputFormat: string, S3BucketSource: Record<string, any>, TableCreationParameters: Record<string, any>, ClientToken?: string, InputCompressionType?: string, InputFormatOptions?: Record<string, any> }) => Promise<ImportTableResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListBackups.html DynamoDB: ListBackups}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#ListBackups DynamoDB: ListBackups}
    */
-  ListBackups: (input: { BackupType?: string, ExclusiveStartBackupArn?: string, Limit?: number, TableName?: string, TimeRangeLowerBound?: number, TimeRangeUpperBound?: number, paginate?: boolean | string }) => Promise<ListBackupsResponse>
+  ListBackups: (input: AwsLiteMethodOptions & { BackupType?: string, ExclusiveStartBackupArn?: string, Limit?: number, TableName?: string, TimeRangeLowerBound?: number, TimeRangeUpperBound?: number, paginate?: boolean | string }) => Promise<ListBackupsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListContributorInsights.html DynamoDB: ListContributorInsights}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#ListContributorInsights DynamoDB: ListContributorInsights}
    */
-  ListContributorInsights: (input: { MaxResults?: number, NextToken?: string, TableName?: string }) => Promise<ListContributorInsightsResponse>
+  ListContributorInsights: (input: AwsLiteMethodOptions & { MaxResults?: number, NextToken?: string, TableName?: string }) => Promise<ListContributorInsightsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListExports.html DynamoDB: ListExports}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#ListExports DynamoDB: ListExports}
    */
-  ListExports: (input: { MaxResults?: number, NextToken?: string, TableArn?: string }) => Promise<ListExportsResponse>
+  ListExports: (input: AwsLiteMethodOptions & { MaxResults?: number, NextToken?: string, TableArn?: string }) => Promise<ListExportsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListGlobalTables.html DynamoDB: ListGlobalTables}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#ListGlobalTables DynamoDB: ListGlobalTables}
    */
-  ListGlobalTables: (input: { ExclusiveStartGlobalTableName?: string, Limit?: number, RegionName?: string }) => Promise<ListGlobalTablesResponse>
+  ListGlobalTables: (input: AwsLiteMethodOptions & { ExclusiveStartGlobalTableName?: string, Limit?: number, RegionName?: string }) => Promise<ListGlobalTablesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListImports.html DynamoDB: ListImports}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#ListImports DynamoDB: ListImports}
    */
-  ListImports: (input: { NextToken?: string, PageSize?: number, TableArn?: string }) => Promise<ListImportsResponse>
+  ListImports: (input: AwsLiteMethodOptions & { NextToken?: string, PageSize?: number, TableArn?: string }) => Promise<ListImportsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListTables.html DynamoDB: ListTables}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#ListTables DynamoDB: ListTables}
    */
-  ListTables: (input: { ExclusiveStartTableName?: string, Limit?: number }) => Promise<ListTablesResponse>
+  ListTables: (input: AwsLiteMethodOptions & { ExclusiveStartTableName?: string, Limit?: number }) => Promise<ListTablesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListTagsOfResource.html DynamoDB: ListTagsOfResource}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#ListTagsOfResource DynamoDB: ListTagsOfResource}
    */
-  ListTagsOfResource: (input: { NextToken?: string, ResourceArn: string }) => Promise<ListTagsOfResourceResponse>
+  ListTagsOfResource: (input: AwsLiteMethodOptions & { NextToken?: string, ResourceArn: string }) => Promise<ListTagsOfResourceResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html DynamoDB: PutItem}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#PutItem DynamoDB: PutItem}
    */
-  PutItem: (input: { TableName: string, Item: Record<string, any>, ConditionalOperator?: string, ConditionExpression?: string, Expected?: Record<string, any>, ExpressionAttributeNames?: Record<string, any>, ExpressionAttributeValues?: Record<string, any>, ReturnConsumedCapacity?: string, ReturnItemCollectionMetrics?: string, ReturnValues?: string, ReturnValuesOnConditionCheckFailure?: string }) => Promise<PutItemResponse>
+  PutItem: (input: AwsLiteMethodOptions & { TableName: string, Item: Record<string, any>, ConditionalOperator?: string, ConditionExpression?: string, Expected?: Record<string, any>, ExpressionAttributeNames?: Record<string, any>, ExpressionAttributeValues?: Record<string, any>, ReturnConsumedCapacity?: string, ReturnItemCollectionMetrics?: string, ReturnValues?: string, ReturnValuesOnConditionCheckFailure?: string }) => Promise<PutItemResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html DynamoDB: Query}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#Query DynamoDB: Query}
    */
-  Query: (input: { TableName: string, AttributesToGet?: any[], ConditionalOperator?: string, ConsistentRead?: boolean, ExclusiveStartKey?: Record<string, any>, ExpressionAttributeNames?: Record<string, any>, ExpressionAttributeValues?: Record<string, any>, FilterExpression?: string, IndexName?: string, KeyConditionExpression?: string, KeyConditions?: Record<string, any>, Limit?: number, ProjectionExpression?: string, QueryFilter?: Record<string, any>, ReturnConsumedCapacity?: string, ScanIndexForward?: boolean, Select?: string, paginate?: boolean | string }) => Promise<QueryResponse>
+  Query: (input: AwsLiteMethodOptions & { TableName: string, AttributesToGet?: any[], ConditionalOperator?: string, ConsistentRead?: boolean, ExclusiveStartKey?: Record<string, any>, ExpressionAttributeNames?: Record<string, any>, ExpressionAttributeValues?: Record<string, any>, FilterExpression?: string, IndexName?: string, KeyConditionExpression?: string, KeyConditions?: Record<string, any>, Limit?: number, ProjectionExpression?: string, QueryFilter?: Record<string, any>, ReturnConsumedCapacity?: string, ScanIndexForward?: boolean, Select?: string, paginate?: boolean | string }) => Promise<QueryResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_RestoreTableFromBackup.html DynamoDB: RestoreTableFromBackup}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#RestoreTableFromBackup DynamoDB: RestoreTableFromBackup}
    */
-  RestoreTableFromBackup: (input: { BackupArn: string, TargetTableName: string, BillingModeOverride?: string, GlobalSecondaryIndexOverride?: any[], LocalSecondaryIndexOverride?: any[], ProvisionedThroughputOverride?: Record<string, any>, SSESpecificationOverride?: Record<string, any> }) => Promise<RestoreTableFromBackupResponse>
+  RestoreTableFromBackup: (input: AwsLiteMethodOptions & { BackupArn: string, TargetTableName: string, BillingModeOverride?: string, GlobalSecondaryIndexOverride?: any[], LocalSecondaryIndexOverride?: any[], ProvisionedThroughputOverride?: Record<string, any>, SSESpecificationOverride?: Record<string, any> }) => Promise<RestoreTableFromBackupResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_RestoreTableToPointInTime.html DynamoDB: RestoreTableToPointInTime}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#RestoreTableToPointInTime DynamoDB: RestoreTableToPointInTime}
    */
-  RestoreTableToPointInTime: (input: { TargetTableName: string, BillingModeOverride?: string, GlobalSecondaryIndexOverride?: any[], LocalSecondaryIndexOverride?: any[], ProvisionedThroughputOverride?: Record<string, any>, RestoreDateTime?: number, SourceTableArn?: string, SourceTableName?: string, SSESpecificationOverride?: Record<string, any>, UseLatestRestorableTime?: boolean }) => Promise<RestoreTableToPointInTimeResponse>
+  RestoreTableToPointInTime: (input: AwsLiteMethodOptions & { TargetTableName: string, BillingModeOverride?: string, GlobalSecondaryIndexOverride?: any[], LocalSecondaryIndexOverride?: any[], ProvisionedThroughputOverride?: Record<string, any>, RestoreDateTime?: number, SourceTableArn?: string, SourceTableName?: string, SSESpecificationOverride?: Record<string, any>, UseLatestRestorableTime?: boolean }) => Promise<RestoreTableToPointInTimeResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html DynamoDB: Scan}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#Scan DynamoDB: Scan}
    */
-  Scan: (input: { TableName: string, AttributesToGet?: any[], ConditionalOperator?: string, ConsistentRead?: boolean, ExclusiveStartKey?: Record<string, any>, ExpressionAttributeNames?: Record<string, any>, ExpressionAttributeValues?: Record<string, any>, FilterExpression?: string, IndexName?: string, Limit?: number, ProjectionExpression?: string, ReturnConsumedCapacity?: string, ScanFilter?: Record<string, any>, Segment?: number, Select?: string, TotalSegments?: number, paginate?: boolean | string }) => Promise<ScanResponse>
+  Scan: (input: AwsLiteMethodOptions & { TableName: string, AttributesToGet?: any[], ConditionalOperator?: string, ConsistentRead?: boolean, ExclusiveStartKey?: Record<string, any>, ExpressionAttributeNames?: Record<string, any>, ExpressionAttributeValues?: Record<string, any>, FilterExpression?: string, IndexName?: string, Limit?: number, ProjectionExpression?: string, ReturnConsumedCapacity?: string, ScanFilter?: Record<string, any>, Segment?: number, Select?: string, TotalSegments?: number, paginate?: boolean | string }) => Promise<ScanResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TagResource.html DynamoDB: TagResource}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#TagResource DynamoDB: TagResource}
    */
-  TagResource: (input: { ResourceArn: string, Tags: any[] }) => Promise<TagResourceResponse>
+  TagResource: (input: AwsLiteMethodOptions & { ResourceArn: string, Tags: any[] }) => Promise<TagResourceResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html DynamoDB: TransactGetItems}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#TransactGetItems DynamoDB: TransactGetItems}
    */
-  TransactGetItems: (input: { TransactItems: any[], ReturnConsumedCapacity?: string }) => Promise<TransactGetItemsResponse>
+  TransactGetItems: (input: AwsLiteMethodOptions & { TransactItems: any[], ReturnConsumedCapacity?: string }) => Promise<TransactGetItemsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html DynamoDB: TransactWriteItems}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#TransactWriteItems DynamoDB: TransactWriteItems}
    */
-  TransactWriteItems: (input: { TransactItems: any[], ClientRequestToken?: string, ReturnConsumedCapacity?: string, ReturnItemCollectionMetrics?: string }) => Promise<TransactWriteItemsResponse>
+  TransactWriteItems: (input: AwsLiteMethodOptions & { TransactItems: any[], ClientRequestToken?: string, ReturnConsumedCapacity?: string, ReturnItemCollectionMetrics?: string }) => Promise<TransactWriteItemsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UntagResource.html DynamoDB: UntagResource}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#UntagResource DynamoDB: UntagResource}
    */
-  UntagResource: (input: { ResourceArn: string, TagKeys: any[] }) => Promise<UntagResourceResponse>
+  UntagResource: (input: AwsLiteMethodOptions & { ResourceArn: string, TagKeys: any[] }) => Promise<UntagResourceResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateContinuousBackups.html DynamoDB: UpdateContinuousBackups}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#UpdateContinuousBackups DynamoDB: UpdateContinuousBackups}
    */
-  UpdateContinuousBackups: (input: { TableName: string, PointInTimeRecoverySpecification?: Record<string, any> }) => Promise<UpdateContinuousBackupsResponse>
+  UpdateContinuousBackups: (input: AwsLiteMethodOptions & { TableName: string, PointInTimeRecoverySpecification?: Record<string, any> }) => Promise<UpdateContinuousBackupsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateContributorInsights.html DynamoDB: UpdateContributorInsights}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#UpdateContributorInsights DynamoDB: UpdateContributorInsights}
    */
-  UpdateContributorInsights: (input: { TableName: string, ContributorInsightsAction?: string, IndexName?: string }) => Promise<UpdateContributorInsightsResponse>
+  UpdateContributorInsights: (input: AwsLiteMethodOptions & { TableName: string, ContributorInsightsAction?: string, IndexName?: string }) => Promise<UpdateContributorInsightsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateGlobalTable.html DynamoDB: UpdateGlobalTable}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#UpdateGlobalTable DynamoDB: UpdateGlobalTable}
    */
-  UpdateGlobalTable: (input: { GlobalTableName: string, ReplicaUpdates?: any[] }) => Promise<UpdateGlobalTableResponse>
+  UpdateGlobalTable: (input: AwsLiteMethodOptions & { GlobalTableName: string, ReplicaUpdates?: any[] }) => Promise<UpdateGlobalTableResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateGlobalTableSettings.html DynamoDB: UpdateGlobalTableSettings}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#UpdateGlobalTableSettings DynamoDB: UpdateGlobalTableSettings}
    */
-  UpdateGlobalTableSettings: (input: { GlobalTableName: string, GlobalTableBillingMode?: string, GlobalTableGlobalSecondaryIndexSettingsUpdate?: any[], GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate?: Record<string, any>, GlobalTableProvisionedWriteCapacityUnits?: number, ReplicaSettingsUpdate?: any[] }) => Promise<UpdateGlobalTableSettingsResponse>
+  UpdateGlobalTableSettings: (input: AwsLiteMethodOptions & { GlobalTableName: string, GlobalTableBillingMode?: string, GlobalTableGlobalSecondaryIndexSettingsUpdate?: any[], GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate?: Record<string, any>, GlobalTableProvisionedWriteCapacityUnits?: number, ReplicaSettingsUpdate?: any[] }) => Promise<UpdateGlobalTableSettingsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html DynamoDB: UpdateItem}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#UpdateItem DynamoDB: UpdateItem}
    */
-  UpdateItem: (input: { Key: Record<string, any>, TableName: string, AttributeUpdates?: Record<string, any>, ConditionalOperator?: string, ConditionExpression?: string, Expected?: Record<string, any>, ExpressionAttributeNames?: Record<string, any>, ExpressionAttributeValues?: Record<string, any>, ReturnConsumedCapacity?: string, ReturnItemCollectionMetrics?: string, ReturnValues?: string, ReturnValuesOnConditionCheckFailure?: string, UpdateExpression?: string }) => Promise<UpdateItemResponse>
+  UpdateItem: (input: AwsLiteMethodOptions & { Key: Record<string, any>, TableName: string, AttributeUpdates?: Record<string, any>, ConditionalOperator?: string, ConditionExpression?: string, Expected?: Record<string, any>, ExpressionAttributeNames?: Record<string, any>, ExpressionAttributeValues?: Record<string, any>, ReturnConsumedCapacity?: string, ReturnItemCollectionMetrics?: string, ReturnValues?: string, ReturnValuesOnConditionCheckFailure?: string, UpdateExpression?: string }) => Promise<UpdateItemResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateTable.html DynamoDB: UpdateTable}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#UpdateTable DynamoDB: UpdateTable}
    */
-  UpdateTable: (input: { TableName: string, AttributeDefinitions?: any[], BillingMode?: string, DeletionProtectionEnabled?: boolean, GlobalSecondaryIndexUpdates?: any[], ProvisionedThroughput?: Record<string, any>, ReplicaUpdates?: any[], SSESpecification?: Record<string, any>, StreamSpecification?: Record<string, any>, TableClass?: string }) => Promise<UpdateTableResponse>
+  UpdateTable: (input: AwsLiteMethodOptions & { TableName: string, AttributeDefinitions?: any[], BillingMode?: string, DeletionProtectionEnabled?: boolean, GlobalSecondaryIndexUpdates?: any[], ProvisionedThroughput?: Record<string, any>, ReplicaUpdates?: any[], SSESpecification?: Record<string, any>, StreamSpecification?: Record<string, any>, TableClass?: string }) => Promise<UpdateTableResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateTableReplicaAutoScaling.html DynamoDB: UpdateTableReplicaAutoScaling}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#UpdateTableReplicaAutoScaling DynamoDB: UpdateTableReplicaAutoScaling}
    */
-  UpdateTableReplicaAutoScaling: (input: { TableName: string, GlobalSecondaryIndexUpdates?: any[], ProvisionedWriteCapacityAutoScalingUpdate?: Record<string, any>, ReplicaUpdates?: any[] }) => Promise<UpdateTableReplicaAutoScalingResponse>
+  UpdateTableReplicaAutoScaling: (input: AwsLiteMethodOptions & { TableName: string, GlobalSecondaryIndexUpdates?: any[], ProvisionedWriteCapacityAutoScalingUpdate?: Record<string, any>, ReplicaUpdates?: any[] }) => Promise<UpdateTableReplicaAutoScalingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateTimeToLive.html DynamoDB: UpdateTimeToLive}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/dynamodb/readme.md#UpdateTimeToLive DynamoDB: UpdateTimeToLive}
    */
-  UpdateTimeToLive: (input: { TableName: string, TimeToLiveSpecification?: Record<string, any> }) => Promise<UpdateTimeToLiveResponse>
+  UpdateTimeToLive: (input: AwsLiteMethodOptions & { TableName: string, TimeToLiveSpecification?: Record<string, any> }) => Promise<UpdateTimeToLiveResponse>
   // $METHODS_END
 }
 

--- a/plugins/iam/types/index.d.ts
+++ b/plugins/iam/types/index.d.ts
@@ -146,6 +146,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-iam";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteIAM {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -154,829 +156,829 @@ declare interface AwsLiteIAM {
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_AddClientIDToOpenIDConnectProvider.html IAM: AddClientIDToOpenIDConnectProvider}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#AddClientIDToOpenIDConnectProvider IAM: AddClientIDToOpenIDConnectProvider}
    */
-  AddClientIDToOpenIDConnectProvider: (input: { ClientID: string, OpenIDConnectProviderArn: string }) => Promise<AddClientIDToOpenIDConnectProviderResponse>
+  AddClientIDToOpenIDConnectProvider: (input: AwsLiteMethodOptions & { ClientID: string, OpenIDConnectProviderArn: string }) => Promise<AddClientIDToOpenIDConnectProviderResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_AddRoleToInstanceProfile.html IAM: AddRoleToInstanceProfile}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#AddRoleToInstanceProfile IAM: AddRoleToInstanceProfile}
    */
-  AddRoleToInstanceProfile: (input: { InstanceProfileName: string, RoleName: string }) => Promise<AddRoleToInstanceProfileResponse>
+  AddRoleToInstanceProfile: (input: AwsLiteMethodOptions & { InstanceProfileName: string, RoleName: string }) => Promise<AddRoleToInstanceProfileResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_AddUserToGroup.html IAM: AddUserToGroup}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#AddUserToGroup IAM: AddUserToGroup}
    */
-  AddUserToGroup: (input: { GroupName: string, UserName: string }) => Promise<AddUserToGroupResponse>
+  AddUserToGroup: (input: AwsLiteMethodOptions & { GroupName: string, UserName: string }) => Promise<AddUserToGroupResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_AttachGroupPolicy.html IAM: AttachGroupPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#AttachGroupPolicy IAM: AttachGroupPolicy}
    */
-  AttachGroupPolicy: (input: { GroupName: string, PolicyArn: string }) => Promise<AttachGroupPolicyResponse>
+  AttachGroupPolicy: (input: AwsLiteMethodOptions & { GroupName: string, PolicyArn: string }) => Promise<AttachGroupPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_AttachRolePolicy.html IAM: AttachRolePolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#AttachRolePolicy IAM: AttachRolePolicy}
    */
-  AttachRolePolicy: (input: { PolicyArn: string, RoleName: string }) => Promise<AttachRolePolicyResponse>
+  AttachRolePolicy: (input: AwsLiteMethodOptions & { PolicyArn: string, RoleName: string }) => Promise<AttachRolePolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_AttachUserPolicy.html IAM: AttachUserPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#AttachUserPolicy IAM: AttachUserPolicy}
    */
-  AttachUserPolicy: (input: { PolicyArn: string, UserName: string }) => Promise<AttachUserPolicyResponse>
+  AttachUserPolicy: (input: AwsLiteMethodOptions & { PolicyArn: string, UserName: string }) => Promise<AttachUserPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ChangePassword.html IAM: ChangePassword}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ChangePassword IAM: ChangePassword}
    */
-  ChangePassword: (input: { NewPassword: string, OldPassword: string }) => Promise<ChangePasswordResponse>
+  ChangePassword: (input: AwsLiteMethodOptions & { NewPassword: string, OldPassword: string }) => Promise<ChangePasswordResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccessKey.html IAM: CreateAccessKey}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#CreateAccessKey IAM: CreateAccessKey}
    */
-  CreateAccessKey: (input: { UserName: string }) => Promise<CreateAccessKeyResponse>
+  CreateAccessKey: (input: AwsLiteMethodOptions & { UserName: string }) => Promise<CreateAccessKeyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccountAlias.html IAM: CreateAccountAlias}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#CreateAccountAlias IAM: CreateAccountAlias}
    */
-  CreateAccountAlias: (input: { AccountAlias: string }) => Promise<CreateAccountAliasResponse>
+  CreateAccountAlias: (input: AwsLiteMethodOptions & { AccountAlias: string }) => Promise<CreateAccountAliasResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateGroup.html IAM: CreateGroup}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#CreateGroup IAM: CreateGroup}
    */
-  CreateGroup: (input: { GroupName: string, Path?: string }) => Promise<CreateGroupResponse>
+  CreateGroup: (input: AwsLiteMethodOptions & { GroupName: string, Path?: string }) => Promise<CreateGroupResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateInstanceProfile.html IAM: CreateInstanceProfile}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#CreateInstanceProfile IAM: CreateInstanceProfile}
    */
-  CreateInstanceProfile: (input: { InstanceProfileName: string, Path?: string, Tags?: any[] }) => Promise<CreateInstanceProfileResponse>
+  CreateInstanceProfile: (input: AwsLiteMethodOptions & { InstanceProfileName: string, Path?: string, Tags?: any[] }) => Promise<CreateInstanceProfileResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateLoginProfile.html IAM: CreateLoginProfile}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#CreateLoginProfile IAM: CreateLoginProfile}
    */
-  CreateLoginProfile: (input: { Password: string, UserName: string, PasswordResetRequired?: boolean }) => Promise<CreateLoginProfileResponse>
+  CreateLoginProfile: (input: AwsLiteMethodOptions & { Password: string, UserName: string, PasswordResetRequired?: boolean }) => Promise<CreateLoginProfileResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateOpenIDConnectProvider.html IAM: CreateOpenIDConnectProvider}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#CreateOpenIDConnectProvider IAM: CreateOpenIDConnectProvider}
    */
-  CreateOpenIDConnectProvider: (input: { Url: string, ClientIDList?: any[], Tags?: any[], ThumbprintList?: any[] }) => Promise<CreateOpenIDConnectProviderResponse>
+  CreateOpenIDConnectProvider: (input: AwsLiteMethodOptions & { Url: string, ClientIDList?: any[], Tags?: any[], ThumbprintList?: any[] }) => Promise<CreateOpenIDConnectProviderResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreatePolicy.html IAM: CreatePolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#CreatePolicy IAM: CreatePolicy}
    */
-  CreatePolicy: (input: { PolicyDocument: string | Record<string, any>, PolicyName: string, Description?: string, Path?: string, Tags?: any[] }) => Promise<CreatePolicyResponse>
+  CreatePolicy: (input: AwsLiteMethodOptions & { PolicyDocument: string | Record<string, any>, PolicyName: string, Description?: string, Path?: string, Tags?: any[] }) => Promise<CreatePolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreatePolicyVersion.html IAM: CreatePolicyVersion}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#CreatePolicyVersion IAM: CreatePolicyVersion}
    */
-  CreatePolicyVersion: (input: { PolicyArn: string, PolicyDocument: string | Record<string, any>, SetAsDefault?: boolean }) => Promise<CreatePolicyVersionResponse>
+  CreatePolicyVersion: (input: AwsLiteMethodOptions & { PolicyArn: string, PolicyDocument: string | Record<string, any>, SetAsDefault?: boolean }) => Promise<CreatePolicyVersionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html IAM: CreateRole}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#CreateRole IAM: CreateRole}
    */
-  CreateRole: (input: { AssumeRolePolicyDocument: string | Record<string, any>, RoleName: string, Description?: string, MaxSessionDuration?: number, Path?: string, PermissionsBoundary?: string, Tags?: any[] }) => Promise<CreateRoleResponse>
+  CreateRole: (input: AwsLiteMethodOptions & { AssumeRolePolicyDocument: string | Record<string, any>, RoleName: string, Description?: string, MaxSessionDuration?: number, Path?: string, PermissionsBoundary?: string, Tags?: any[] }) => Promise<CreateRoleResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateServiceLinkedRole.html IAM: CreateServiceLinkedRole}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#CreateServiceLinkedRole IAM: CreateServiceLinkedRole}
    */
-  CreateServiceLinkedRole: (input: { AWSServiceName: string, CustomSuffix?: string, Description?: string }) => Promise<CreateServiceLinkedRoleResponse>
+  CreateServiceLinkedRole: (input: AwsLiteMethodOptions & { AWSServiceName: string, CustomSuffix?: string, Description?: string }) => Promise<CreateServiceLinkedRoleResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateServiceSpecificCredential.html IAM: CreateServiceSpecificCredential}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#CreateServiceSpecificCredential IAM: CreateServiceSpecificCredential}
    */
-  CreateServiceSpecificCredential: (input: { ServiceName: string, UserName: string }) => Promise<CreateServiceSpecificCredentialResponse>
+  CreateServiceSpecificCredential: (input: AwsLiteMethodOptions & { ServiceName: string, UserName: string }) => Promise<CreateServiceSpecificCredentialResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateUser.html IAM: CreateUser}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#CreateUser IAM: CreateUser}
    */
-  CreateUser: (input: { UserName: string, Path?: string, PermissionsBoundary?: string, Tags?: any[] }) => Promise<CreateUserResponse>
+  CreateUser: (input: AwsLiteMethodOptions & { UserName: string, Path?: string, PermissionsBoundary?: string, Tags?: any[] }) => Promise<CreateUserResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateVirtualMFADevice.html IAM: CreateVirtualMFADevice}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#CreateVirtualMFADevice IAM: CreateVirtualMFADevice}
    */
-  CreateVirtualMFADevice: (input: { VirtualMFADeviceName: string, Path?: string, Tags?: any[] }) => Promise<CreateVirtualMFADeviceResponse>
+  CreateVirtualMFADevice: (input: AwsLiteMethodOptions & { VirtualMFADeviceName: string, Path?: string, Tags?: any[] }) => Promise<CreateVirtualMFADeviceResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteAccessKey.html IAM: DeleteAccessKey}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteAccessKey IAM: DeleteAccessKey}
    */
-  DeleteAccessKey: (input: { AccessKeyId: string, UserName?: string }) => Promise<DeleteAccessKeyResponse>
+  DeleteAccessKey: (input: AwsLiteMethodOptions & { AccessKeyId: string, UserName?: string }) => Promise<DeleteAccessKeyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteAccountAlias.html IAM: DeleteAccountAlias}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteAccountAlias IAM: DeleteAccountAlias}
    */
-  DeleteAccountAlias: (input: { AccountAlias: string }) => Promise<DeleteAccountAliasResponse>
+  DeleteAccountAlias: (input: AwsLiteMethodOptions & { AccountAlias: string }) => Promise<DeleteAccountAliasResponse>
   /** @description aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteAccountPasswordPolicy IAM: DeleteAccountPasswordPolicy} */
-  DeleteAccountPasswordPolicy: () => Promise<DeleteAccountPasswordPolicyResponse>
+  DeleteAccountPasswordPolicy: (input?: AwsLiteMethodOptions) => Promise<DeleteAccountPasswordPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteGroup.html IAM: DeleteGroup}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteGroup IAM: DeleteGroup}
    */
-  DeleteGroup: (input: { GroupName: string }) => Promise<DeleteGroupResponse>
+  DeleteGroup: (input: AwsLiteMethodOptions & { GroupName: string }) => Promise<DeleteGroupResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteGroupPolicy.html IAM: DeleteGroupPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteGroupPolicy IAM: DeleteGroupPolicy}
    */
-  DeleteGroupPolicy: (input: { GroupName: string, PolicyName: string }) => Promise<DeleteGroupPolicyResponse>
+  DeleteGroupPolicy: (input: AwsLiteMethodOptions & { GroupName: string, PolicyName: string }) => Promise<DeleteGroupPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteInstanceProfile.html IAM: DeleteInstanceProfile}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteInstanceProfile IAM: DeleteInstanceProfile}
    */
-  DeleteInstanceProfile: (input: { InstanceProfileName: string }) => Promise<DeleteInstanceProfileResponse>
+  DeleteInstanceProfile: (input: AwsLiteMethodOptions & { InstanceProfileName: string }) => Promise<DeleteInstanceProfileResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteLoginProfile.html IAM: DeleteLoginProfile}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteLoginProfile IAM: DeleteLoginProfile}
    */
-  DeleteLoginProfile: (input: { UserName: string }) => Promise<DeleteLoginProfileResponse>
+  DeleteLoginProfile: (input: AwsLiteMethodOptions & { UserName: string }) => Promise<DeleteLoginProfileResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteOpenIDConnectProvider.html IAM: DeleteOpenIDConnectProvider}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteOpenIDConnectProvider IAM: DeleteOpenIDConnectProvider}
    */
-  DeleteOpenIDConnectProvider: (input: { OpenIDConnectProviderArn: string }) => Promise<DeleteOpenIDConnectProviderResponse>
+  DeleteOpenIDConnectProvider: (input: AwsLiteMethodOptions & { OpenIDConnectProviderArn: string }) => Promise<DeleteOpenIDConnectProviderResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeletePolicy.html IAM: DeletePolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeletePolicy IAM: DeletePolicy}
    */
-  DeletePolicy: (input: { PolicyArn: string }) => Promise<DeletePolicyResponse>
+  DeletePolicy: (input: AwsLiteMethodOptions & { PolicyArn: string }) => Promise<DeletePolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeletePolicyVersion.html IAM: DeletePolicyVersion}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeletePolicyVersion IAM: DeletePolicyVersion}
    */
-  DeletePolicyVersion: (input: { PolicyArn: string, VersionId: string }) => Promise<DeletePolicyVersionResponse>
+  DeletePolicyVersion: (input: AwsLiteMethodOptions & { PolicyArn: string, VersionId: string }) => Promise<DeletePolicyVersionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteRole.html IAM: DeleteRole}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteRole IAM: DeleteRole}
    */
-  DeleteRole: (input: { RoleName: string }) => Promise<DeleteRoleResponse>
+  DeleteRole: (input: AwsLiteMethodOptions & { RoleName: string }) => Promise<DeleteRoleResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteRolePermissionsBoundary.html IAM: DeleteRolePermissionsBoundary}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteRolePermissionsBoundary IAM: DeleteRolePermissionsBoundary}
    */
-  DeleteRolePermissionsBoundary: (input: { RoleName: string }) => Promise<DeleteRolePermissionsBoundaryResponse>
+  DeleteRolePermissionsBoundary: (input: AwsLiteMethodOptions & { RoleName: string }) => Promise<DeleteRolePermissionsBoundaryResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteRolePolicy.html IAM: DeleteRolePolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteRolePolicy IAM: DeleteRolePolicy}
    */
-  DeleteRolePolicy: (input: { RoleName: string, PolicyName: string }) => Promise<DeleteRolePolicyResponse>
+  DeleteRolePolicy: (input: AwsLiteMethodOptions & { RoleName: string, PolicyName: string }) => Promise<DeleteRolePolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteServerCertificate.html IAM: DeleteServerCertificate}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteServerCertificate IAM: DeleteServerCertificate}
    */
-  DeleteServerCertificate: (input: { ServerCertificateName: string }) => Promise<DeleteServerCertificateResponse>
+  DeleteServerCertificate: (input: AwsLiteMethodOptions & { ServerCertificateName: string }) => Promise<DeleteServerCertificateResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteServiceLinkedRole.html IAM: DeleteServiceLinkedRole}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteServiceLinkedRole IAM: DeleteServiceLinkedRole}
    */
-  DeleteServiceLinkedRole: (input: { RoleName: string }) => Promise<DeleteServiceLinkedRoleResponse>
+  DeleteServiceLinkedRole: (input: AwsLiteMethodOptions & { RoleName: string }) => Promise<DeleteServiceLinkedRoleResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteServiceSpecificCredential.html IAM: DeleteServiceSpecificCredential}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteServiceSpecificCredential IAM: DeleteServiceSpecificCredential}
    */
-  DeleteServiceSpecificCredential: (input: { ServiceSpecificCredentialId: string, UserName: string }) => Promise<DeleteServiceSpecificCredentialResponse>
+  DeleteServiceSpecificCredential: (input: AwsLiteMethodOptions & { ServiceSpecificCredentialId: string, UserName: string }) => Promise<DeleteServiceSpecificCredentialResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteSigningCertificate.html IAM: DeleteSigningCertificate}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteSigningCertificate IAM: DeleteSigningCertificate}
    */
-  DeleteSigningCertificate: (input: { CertificateId: string, UserName?: string }) => Promise<DeleteSigningCertificateResponse>
+  DeleteSigningCertificate: (input: AwsLiteMethodOptions & { CertificateId: string, UserName?: string }) => Promise<DeleteSigningCertificateResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteSSHPublicKey.html IAM: DeleteSSHPublicKey}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteSSHPublicKey IAM: DeleteSSHPublicKey}
    */
-  DeleteSSHPublicKey: (input: { SSHPublicKeyId: string, UserName: string }) => Promise<DeleteSSHPublicKeyResponse>
+  DeleteSSHPublicKey: (input: AwsLiteMethodOptions & { SSHPublicKeyId: string, UserName: string }) => Promise<DeleteSSHPublicKeyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteUser.html IAM: DeleteUser}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteUser IAM: DeleteUser}
    */
-  DeleteUser: (input: { UserName: string }) => Promise<DeleteUserResponse>
+  DeleteUser: (input: AwsLiteMethodOptions & { UserName: string }) => Promise<DeleteUserResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteUserPermissionsBoundary.html IAM: DeleteUserPermissionsBoundary}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteUserPermissionsBoundary IAM: DeleteUserPermissionsBoundary}
    */
-  DeleteUserPermissionsBoundary: (input: { UserName: string }) => Promise<DeleteUserPermissionsBoundaryResponse>
+  DeleteUserPermissionsBoundary: (input: AwsLiteMethodOptions & { UserName: string }) => Promise<DeleteUserPermissionsBoundaryResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteUserPolicy.html IAM: DeleteUserPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteUserPolicy IAM: DeleteUserPolicy}
    */
-  DeleteUserPolicy: (input: { PolicyName: string, UserName: string }) => Promise<DeleteUserPolicyResponse>
+  DeleteUserPolicy: (input: AwsLiteMethodOptions & { PolicyName: string, UserName: string }) => Promise<DeleteUserPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteVirtualMFADevice.html IAM: DeleteVirtualMFADevice}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DeleteVirtualMFADevice IAM: DeleteVirtualMFADevice}
    */
-  DeleteVirtualMFADevice: (input: { SerialNumber: string }) => Promise<DeleteVirtualMFADeviceResponse>
+  DeleteVirtualMFADevice: (input: AwsLiteMethodOptions & { SerialNumber: string }) => Promise<DeleteVirtualMFADeviceResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DetachGroupPolicy.html IAM: DetachGroupPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DetachGroupPolicy IAM: DetachGroupPolicy}
    */
-  DetachGroupPolicy: (input: { GroupName: string, PolicyArn: string }) => Promise<DetachGroupPolicyResponse>
+  DetachGroupPolicy: (input: AwsLiteMethodOptions & { GroupName: string, PolicyArn: string }) => Promise<DetachGroupPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DetachRolePolicy.html IAM: DetachRolePolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DetachRolePolicy IAM: DetachRolePolicy}
    */
-  DetachRolePolicy: (input: { PolicyArn: string, RoleName: string }) => Promise<DetachRolePolicyResponse>
+  DetachRolePolicy: (input: AwsLiteMethodOptions & { PolicyArn: string, RoleName: string }) => Promise<DetachRolePolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_DetachUserPolicy.html IAM: DetachUserPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#DetachUserPolicy IAM: DetachUserPolicy}
    */
-  DetachUserPolicy: (input: { PolicyArn: string, UserName: string }) => Promise<DetachUserPolicyResponse>
+  DetachUserPolicy: (input: AwsLiteMethodOptions & { PolicyArn: string, UserName: string }) => Promise<DetachUserPolicyResponse>
   /** @description aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GenerateCredentialReport IAM: GenerateCredentialReport} */
-  GenerateCredentialReport: () => Promise<GenerateCredentialReportResponse>
+  GenerateCredentialReport: (input?: AwsLiteMethodOptions) => Promise<GenerateCredentialReportResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GenerateOrganizationsAccessReport.html IAM: GenerateOrganizationsAccessReport}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GenerateOrganizationsAccessReport IAM: GenerateOrganizationsAccessReport}
    */
-  GenerateOrganizationsAccessReport: (input: { EntityPath: string, OrganizationsPolicyId?: string }) => Promise<GenerateOrganizationsAccessReportResponse>
+  GenerateOrganizationsAccessReport: (input: AwsLiteMethodOptions & { EntityPath: string, OrganizationsPolicyId?: string }) => Promise<GenerateOrganizationsAccessReportResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GenerateServiceLastAccessedDetails.html IAM: GenerateServiceLastAccessedDetails}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GenerateServiceLastAccessedDetails IAM: GenerateServiceLastAccessedDetails}
    */
-  GenerateServiceLastAccessedDetails: (input: { Arn: string, Granularity?: string }) => Promise<GenerateServiceLastAccessedDetailsResponse>
+  GenerateServiceLastAccessedDetails: (input: AwsLiteMethodOptions & { Arn: string, Granularity?: string }) => Promise<GenerateServiceLastAccessedDetailsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetAccessKeyLastUsed.html IAM: GetAccessKeyLastUsed}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetAccessKeyLastUsed IAM: GetAccessKeyLastUsed}
    */
-  GetAccessKeyLastUsed: (input: { AccessKeyId: string }) => Promise<GetAccessKeyLastUsedResponse>
+  GetAccessKeyLastUsed: (input: AwsLiteMethodOptions & { AccessKeyId: string }) => Promise<GetAccessKeyLastUsedResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetAccountAuthorizationDetails.html IAM: GetAccountAuthorizationDetails}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetAccountAuthorizationDetails IAM: GetAccountAuthorizationDetails}
    */
-  GetAccountAuthorizationDetails: (input: { Filter?: any[], Marker?: string, MaxItems?: number, paginate?: string }) => Promise<GetAccountAuthorizationDetailsResponse>
+  GetAccountAuthorizationDetails: (input: AwsLiteMethodOptions & { Filter?: any[], Marker?: string, MaxItems?: number, paginate?: string }) => Promise<GetAccountAuthorizationDetailsResponse>
   /** @description aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetAccountPasswordPolicy IAM: GetAccountPasswordPolicy} */
-  GetAccountPasswordPolicy: () => Promise<GetAccountPasswordPolicyResponse>
+  GetAccountPasswordPolicy: (input?: AwsLiteMethodOptions) => Promise<GetAccountPasswordPolicyResponse>
   /** @description aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetAccountSummary IAM: GetAccountSummary} */
-  GetAccountSummary: () => Promise<GetAccountSummaryResponse>
+  GetAccountSummary: (input?: AwsLiteMethodOptions) => Promise<GetAccountSummaryResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetContextKeysForCustomPolicy.html IAM: GetContextKeysForCustomPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetContextKeysForCustomPolicy IAM: GetContextKeysForCustomPolicy}
    */
-  GetContextKeysForCustomPolicy: (input: { PolicyInputList: any[] }) => Promise<GetContextKeysForCustomPolicyResponse>
+  GetContextKeysForCustomPolicy: (input: AwsLiteMethodOptions & { PolicyInputList: any[] }) => Promise<GetContextKeysForCustomPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetContextKeysForPrincipalPolicy.html IAM: GetContextKeysForPrincipalPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetContextKeysForPrincipalPolicy IAM: GetContextKeysForPrincipalPolicy}
    */
-  GetContextKeysForPrincipalPolicy: (input: { PolicySourceArn: string, PolicyInputList?: any[] }) => Promise<GetContextKeysForPrincipalPolicyResponse>
+  GetContextKeysForPrincipalPolicy: (input: AwsLiteMethodOptions & { PolicySourceArn: string, PolicyInputList?: any[] }) => Promise<GetContextKeysForPrincipalPolicyResponse>
   /** @description aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetCredentialReport IAM: GetCredentialReport} */
-  GetCredentialReport: () => Promise<GetCredentialReportResponse>
+  GetCredentialReport: (input?: AwsLiteMethodOptions) => Promise<GetCredentialReportResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetGroup.html IAM: GetGroup}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetGroup IAM: GetGroup}
    */
-  GetGroup: (input: { GroupName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<GetGroupResponse>
+  GetGroup: (input: AwsLiteMethodOptions & { GroupName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<GetGroupResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetGroupPolicy.html IAM: GetGroupPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetGroupPolicy IAM: GetGroupPolicy}
    */
-  GetGroupPolicy: (input: { GroupName: string, PolicyName: string }) => Promise<GetGroupPolicyResponse>
+  GetGroupPolicy: (input: AwsLiteMethodOptions & { GroupName: string, PolicyName: string }) => Promise<GetGroupPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetInstanceProfile.html IAM: GetInstanceProfile}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetInstanceProfile IAM: GetInstanceProfile}
    */
-  GetInstanceProfile: (input: { InstanceProfileName: string }) => Promise<GetInstanceProfileResponse>
+  GetInstanceProfile: (input: AwsLiteMethodOptions & { InstanceProfileName: string }) => Promise<GetInstanceProfileResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetLoginProfile.html IAM: GetLoginProfile}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetLoginProfile IAM: GetLoginProfile}
    */
-  GetLoginProfile: (input: { UserName: string }) => Promise<GetLoginProfileResponse>
+  GetLoginProfile: (input: AwsLiteMethodOptions & { UserName: string }) => Promise<GetLoginProfileResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetOpenIDConnectProvider.html IAM: GetOpenIDConnectProvider}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetOpenIDConnectProvider IAM: GetOpenIDConnectProvider}
    */
-  GetOpenIDConnectProvider: (input: { OpenIDConnectProviderArn: string }) => Promise<GetOpenIDConnectProviderResponse>
+  GetOpenIDConnectProvider: (input: AwsLiteMethodOptions & { OpenIDConnectProviderArn: string }) => Promise<GetOpenIDConnectProviderResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetOrganizationsAccessReport.html IAM: GetOrganizationsAccessReport}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetOrganizationsAccessReport IAM: GetOrganizationsAccessReport}
    */
-  GetOrganizationsAccessReport: (input: { JobId: string, Marker?: string, MaxItems?: number, SortKey?: string, paginate?: boolean | string }) => Promise<GetOrganizationsAccessReportResponse>
+  GetOrganizationsAccessReport: (input: AwsLiteMethodOptions & { JobId: string, Marker?: string, MaxItems?: number, SortKey?: string, paginate?: boolean | string }) => Promise<GetOrganizationsAccessReportResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetPolicy.html IAM: GetPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetPolicy IAM: GetPolicy}
    */
-  GetPolicy: (input: { PolicyArn: string }) => Promise<GetPolicyResponse>
+  GetPolicy: (input: AwsLiteMethodOptions & { PolicyArn: string }) => Promise<GetPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetPolicyVersion.html IAM: GetPolicyVersion}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetPolicyVersion IAM: GetPolicyVersion}
    */
-  GetPolicyVersion: (input: { PolicyArn: string, VersionId: string }) => Promise<GetPolicyVersionResponse>
+  GetPolicyVersion: (input: AwsLiteMethodOptions & { PolicyArn: string, VersionId: string }) => Promise<GetPolicyVersionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetRole.html IAM: GetRole}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetRole IAM: GetRole}
    */
-  GetRole: (input: { RoleName: string }) => Promise<GetRoleResponse>
+  GetRole: (input: AwsLiteMethodOptions & { RoleName: string }) => Promise<GetRoleResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetRolePolicy.html IAM: GetRolePolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetRolePolicy IAM: GetRolePolicy}
    */
-  GetRolePolicy: (input: { PolicyName: string, RoleName: string }) => Promise<GetRolePolicyResponse>
+  GetRolePolicy: (input: AwsLiteMethodOptions & { PolicyName: string, RoleName: string }) => Promise<GetRolePolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetServerCertificate.html IAM: GetServerCertificate}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetServerCertificate IAM: GetServerCertificate}
    */
-  GetServerCertificate: (input: { ServerCertificateName: string }) => Promise<GetServerCertificateResponse>
+  GetServerCertificate: (input: AwsLiteMethodOptions & { ServerCertificateName: string }) => Promise<GetServerCertificateResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetServiceLastAccessedDetails.html IAM: GetServiceLastAccessedDetails}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetServiceLastAccessedDetails IAM: GetServiceLastAccessedDetails}
    */
-  GetServiceLastAccessedDetails: (input: { JobId: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<GetServiceLastAccessedDetailsResponse>
+  GetServiceLastAccessedDetails: (input: AwsLiteMethodOptions & { JobId: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<GetServiceLastAccessedDetailsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetServiceLastAccessedDetailsWithEntities.html IAM: GetServiceLastAccessedDetailsWithEntities}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetServiceLastAccessedDetailsWithEntities IAM: GetServiceLastAccessedDetailsWithEntities}
    */
-  GetServiceLastAccessedDetailsWithEntities: (input: { JobId: string, ServiceNamespace: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<GetServiceLastAccessedDetailsWithEntitiesResponse>
+  GetServiceLastAccessedDetailsWithEntities: (input: AwsLiteMethodOptions & { JobId: string, ServiceNamespace: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<GetServiceLastAccessedDetailsWithEntitiesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetSSHPublicKey.html IAM: GetSSHPublicKey}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetSSHPublicKey IAM: GetSSHPublicKey}
    */
-  GetSSHPublicKey: (input: { Encoding: string, SSHPublicKeyId: string, UserName: string }) => Promise<GetSSHPublicKeyResponse>
+  GetSSHPublicKey: (input: AwsLiteMethodOptions & { Encoding: string, SSHPublicKeyId: string, UserName: string }) => Promise<GetSSHPublicKeyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetUser.html IAM: GetUser}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetUser IAM: GetUser}
    */
-  GetUser: (input: { UserName: string }) => Promise<GetUserResponse>
+  GetUser: (input: AwsLiteMethodOptions & { UserName: string }) => Promise<GetUserResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetUserPolicy.html IAM: GetUserPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#GetUserPolicy IAM: GetUserPolicy}
    */
-  GetUserPolicy: (input: { PolicyName: string, UserName: string }) => Promise<GetUserPolicyResponse>
+  GetUserPolicy: (input: AwsLiteMethodOptions & { PolicyName: string, UserName: string }) => Promise<GetUserPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListAccessKeys.html IAM: ListAccessKeys}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListAccessKeys IAM: ListAccessKeys}
    */
-  ListAccessKeys: (input: { Marker?: string, MaxItems?: number, UserName?: string, paginate?: boolean | string }) => Promise<ListAccessKeysResponse>
+  ListAccessKeys: (input: AwsLiteMethodOptions & { Marker?: string, MaxItems?: number, UserName?: string, paginate?: boolean | string }) => Promise<ListAccessKeysResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListAccountAliases.html IAM: ListAccountAliases}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListAccountAliases IAM: ListAccountAliases}
    */
-  ListAccountAliases: (input: { Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListAccountAliasesResponse>
+  ListAccountAliases: (input: AwsLiteMethodOptions & { Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListAccountAliasesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListAttachedGroupPolicies.html IAM: ListAttachedGroupPolicies}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListAttachedGroupPolicies IAM: ListAttachedGroupPolicies}
    */
-  ListAttachedGroupPolicies: (input: { GroupName: string, Marker?: string, PathPrefix?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListAttachedGroupPoliciesResponse>
+  ListAttachedGroupPolicies: (input: AwsLiteMethodOptions & { GroupName: string, Marker?: string, PathPrefix?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListAttachedGroupPoliciesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListAttachedRolePolicies.html IAM: ListAttachedRolePolicies}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListAttachedRolePolicies IAM: ListAttachedRolePolicies}
    */
-  ListAttachedRolePolicies: (input: { RoleName: string, Marker?: string, PathPrefix?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListAttachedRolePoliciesResponse>
+  ListAttachedRolePolicies: (input: AwsLiteMethodOptions & { RoleName: string, Marker?: string, PathPrefix?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListAttachedRolePoliciesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListAttachedUserPolicies.html IAM: ListAttachedUserPolicies}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListAttachedUserPolicies IAM: ListAttachedUserPolicies}
    */
-  ListAttachedUserPolicies: (input: { UserName: string, Marker?: string, PathPrefix?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListAttachedUserPoliciesResponse>
+  ListAttachedUserPolicies: (input: AwsLiteMethodOptions & { UserName: string, Marker?: string, PathPrefix?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListAttachedUserPoliciesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListEntitiesForPolicy.html IAM: ListEntitiesForPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListEntitiesForPolicy IAM: ListEntitiesForPolicy}
    */
-  ListEntitiesForPolicy: (input: { PolicyArn: string, EntityFilter?: string, Marker?: string, MaxItems?: number, PathPrefix?: string, PolicyUsageFilter?: string, paginate?: string }) => Promise<ListEntitiesForPolicyResponse>
+  ListEntitiesForPolicy: (input: AwsLiteMethodOptions & { PolicyArn: string, EntityFilter?: string, Marker?: string, MaxItems?: number, PathPrefix?: string, PolicyUsageFilter?: string, paginate?: string }) => Promise<ListEntitiesForPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListGroupPolicies.html IAM: ListGroupPolicies}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListGroupPolicies IAM: ListGroupPolicies}
    */
-  ListGroupPolicies: (input: { GroupName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListGroupPoliciesResponse>
+  ListGroupPolicies: (input: AwsLiteMethodOptions & { GroupName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListGroupPoliciesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListGroups.html IAM: ListGroups}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListGroups IAM: ListGroups}
    */
-  ListGroups: (input: { Marker?: string, MaxItems?: number, PathPrefix?: string, paginate?: boolean | string }) => Promise<ListGroupsResponse>
+  ListGroups: (input: AwsLiteMethodOptions & { Marker?: string, MaxItems?: number, PathPrefix?: string, paginate?: boolean | string }) => Promise<ListGroupsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListGroupsForUser.html IAM: ListGroupsForUser}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListGroupsForUser IAM: ListGroupsForUser}
    */
-  ListGroupsForUser: (input: { UserName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListGroupsForUserResponse>
+  ListGroupsForUser: (input: AwsLiteMethodOptions & { UserName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListGroupsForUserResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListInstanceProfiles.html IAM: ListInstanceProfiles}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListInstanceProfiles IAM: ListInstanceProfiles}
    */
-  ListInstanceProfiles: (input: { Marker?: string, MaxItems?: number, PathPrefix?: string, paginate?: boolean | string }) => Promise<ListInstanceProfilesResponse>
+  ListInstanceProfiles: (input: AwsLiteMethodOptions & { Marker?: string, MaxItems?: number, PathPrefix?: string, paginate?: boolean | string }) => Promise<ListInstanceProfilesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListInstanceProfilesForRole.html IAM: ListInstanceProfilesForRole}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListInstanceProfilesForRole IAM: ListInstanceProfilesForRole}
    */
-  ListInstanceProfilesForRole: (input: { RoleName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListInstanceProfilesForRoleResponse>
+  ListInstanceProfilesForRole: (input: AwsLiteMethodOptions & { RoleName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListInstanceProfilesForRoleResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListInstanceProfileTags.html IAM: ListInstanceProfileTags}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListInstanceProfileTags IAM: ListInstanceProfileTags}
    */
-  ListInstanceProfileTags: (input: { InstanceProfileName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListInstanceProfileTagsResponse>
+  ListInstanceProfileTags: (input: AwsLiteMethodOptions & { InstanceProfileName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListInstanceProfileTagsResponse>
   /** @description aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListOpenIDConnectProviders IAM: ListOpenIDConnectProviders} */
-  ListOpenIDConnectProviders: () => Promise<ListOpenIDConnectProvidersResponse>
+  ListOpenIDConnectProviders: (input?: AwsLiteMethodOptions) => Promise<ListOpenIDConnectProvidersResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListOpenIDConnectProviderTags.html IAM: ListOpenIDConnectProviderTags}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListOpenIDConnectProviderTags IAM: ListOpenIDConnectProviderTags}
    */
-  ListOpenIDConnectProviderTags: (input: { OpenIDConnectProviderArn: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListOpenIDConnectProviderTagsResponse>
+  ListOpenIDConnectProviderTags: (input: AwsLiteMethodOptions & { OpenIDConnectProviderArn: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListOpenIDConnectProviderTagsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListPolicies.html IAM: ListPolicies}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListPolicies IAM: ListPolicies}
    */
-  ListPolicies: (input: { Marker?: string, MaxItems?: number, OnlyAttached?: boolean, PathPrefix?: string, PolicyUsageFilter?: string, Scope?: string, paginate?: boolean | string }) => Promise<ListPoliciesResponse>
+  ListPolicies: (input: AwsLiteMethodOptions & { Marker?: string, MaxItems?: number, OnlyAttached?: boolean, PathPrefix?: string, PolicyUsageFilter?: string, Scope?: string, paginate?: boolean | string }) => Promise<ListPoliciesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListPoliciesGrantingServiceAccess.html IAM: ListPoliciesGrantingServiceAccess}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListPoliciesGrantingServiceAccess IAM: ListPoliciesGrantingServiceAccess}
    */
-  ListPoliciesGrantingServiceAccess: (input: { Arn: string, ServiceNamespaces: any[], Marker?: string, paginate?: boolean | string }) => Promise<ListPoliciesGrantingServiceAccessResponse>
+  ListPoliciesGrantingServiceAccess: (input: AwsLiteMethodOptions & { Arn: string, ServiceNamespaces: any[], Marker?: string, paginate?: boolean | string }) => Promise<ListPoliciesGrantingServiceAccessResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListPolicyTags.html IAM: ListPolicyTags}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListPolicyTags IAM: ListPolicyTags}
    */
-  ListPolicyTags: (input: { PolicyArn: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListPolicyTagsResponse>
+  ListPolicyTags: (input: AwsLiteMethodOptions & { PolicyArn: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListPolicyTagsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListPolicyVersions.html IAM: ListPolicyVersions}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListPolicyVersions IAM: ListPolicyVersions}
    */
-  ListPolicyVersions: (input: { PolicyArn: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListPolicyVersionsResponse>
+  ListPolicyVersions: (input: AwsLiteMethodOptions & { PolicyArn: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListPolicyVersionsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListRolePolicies.html IAM: ListRolePolicies}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListRolePolicies IAM: ListRolePolicies}
    */
-  ListRolePolicies: (input: { RoleName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListRolePoliciesResponse>
+  ListRolePolicies: (input: AwsLiteMethodOptions & { RoleName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListRolePoliciesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListRoles.html IAM: ListRoles}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListRoles IAM: ListRoles}
    */
-  ListRoles: (input: { Marker?: string, MaxItems?: number, PathPrefix?: string, paginate?: boolean | string }) => Promise<ListRolesResponse>
+  ListRoles: (input: AwsLiteMethodOptions & { Marker?: string, MaxItems?: number, PathPrefix?: string, paginate?: boolean | string }) => Promise<ListRolesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListRoleTags.html IAM: ListRoleTags}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListRoleTags IAM: ListRoleTags}
    */
-  ListRoleTags: (input: { RoleName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListRoleTagsResponse>
+  ListRoleTags: (input: AwsLiteMethodOptions & { RoleName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListRoleTagsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListServerCertificates.html IAM: ListServerCertificates}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListServerCertificates IAM: ListServerCertificates}
    */
-  ListServerCertificates: (input: { Marker?: string, MaxItems?: number, PathPrefix?: string, paginate?: boolean | string }) => Promise<ListServerCertificatesResponse>
+  ListServerCertificates: (input: AwsLiteMethodOptions & { Marker?: string, MaxItems?: number, PathPrefix?: string, paginate?: boolean | string }) => Promise<ListServerCertificatesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListServerCertificateTags.html IAM: ListServerCertificateTags}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListServerCertificateTags IAM: ListServerCertificateTags}
    */
-  ListServerCertificateTags: (input: { ServerCertificateName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListServerCertificateTagsResponse>
+  ListServerCertificateTags: (input: AwsLiteMethodOptions & { ServerCertificateName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListServerCertificateTagsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListServiceSpecificCredentials.html IAM: ListServiceSpecificCredentials}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListServiceSpecificCredentials IAM: ListServiceSpecificCredentials}
    */
-  ListServiceSpecificCredentials: (input: { ServiceName?: string, UserName?: string }) => Promise<ListServiceSpecificCredentialsResponse>
+  ListServiceSpecificCredentials: (input: AwsLiteMethodOptions & { ServiceName?: string, UserName?: string }) => Promise<ListServiceSpecificCredentialsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListSigningCertificates.html IAM: ListSigningCertificates}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListSigningCertificates IAM: ListSigningCertificates}
    */
-  ListSigningCertificates: (input: { Marker?: string, MaxItems?: number, UserName?: string }) => Promise<ListSigningCertificatesResponse>
+  ListSigningCertificates: (input: AwsLiteMethodOptions & { Marker?: string, MaxItems?: number, UserName?: string }) => Promise<ListSigningCertificatesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListSSHPublicKeys.html IAM: ListSSHPublicKeys}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListSSHPublicKeys IAM: ListSSHPublicKeys}
    */
-  ListSSHPublicKeys: (input: { Marker?: string, MaxItems?: number, UserName?: string }) => Promise<ListSSHPublicKeysResponse>
+  ListSSHPublicKeys: (input: AwsLiteMethodOptions & { Marker?: string, MaxItems?: number, UserName?: string }) => Promise<ListSSHPublicKeysResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListUserPolicies.html IAM: ListUserPolicies}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListUserPolicies IAM: ListUserPolicies}
    */
-  ListUserPolicies: (input: { UserName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListUserPoliciesResponse>
+  ListUserPolicies: (input: AwsLiteMethodOptions & { UserName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListUserPoliciesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListUsers.html IAM: ListUsers}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListUsers IAM: ListUsers}
    */
-  ListUsers: (input: { Marker?: string, MaxItems?: number, PathPrefix?: string, paginate?: boolean | string }) => Promise<ListUsersResponse>
+  ListUsers: (input: AwsLiteMethodOptions & { Marker?: string, MaxItems?: number, PathPrefix?: string, paginate?: boolean | string }) => Promise<ListUsersResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListUserTags.html IAM: ListUserTags}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListUserTags IAM: ListUserTags}
    */
-  ListUserTags: (input: { UserName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListUserTagsResponse>
+  ListUserTags: (input: AwsLiteMethodOptions & { UserName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListUserTagsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListVirtualMFADevices.html IAM: ListVirtualMFADevices}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ListVirtualMFADevices IAM: ListVirtualMFADevices}
    */
-  ListVirtualMFADevices: (input: { AssignmentStatus?: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListVirtualMFADevicesResponse>
+  ListVirtualMFADevices: (input: AwsLiteMethodOptions & { AssignmentStatus?: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListVirtualMFADevicesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_PutGroupPolicy.html IAM: PutGroupPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#PutGroupPolicy IAM: PutGroupPolicy}
    */
-  PutGroupPolicy: (input: { GroupName: string, PolicyDocument: string | Record<string, any>, PolicyName: string }) => Promise<PutGroupPolicyResponse>
+  PutGroupPolicy: (input: AwsLiteMethodOptions & { GroupName: string, PolicyDocument: string | Record<string, any>, PolicyName: string }) => Promise<PutGroupPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_PutRolePermissionsBoundary.html IAM: PutRolePermissionsBoundary}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#PutRolePermissionsBoundary IAM: PutRolePermissionsBoundary}
    */
-  PutRolePermissionsBoundary: (input: { PermissionsBoundary: string, RoleName: string }) => Promise<PutRolePermissionsBoundaryResponse>
+  PutRolePermissionsBoundary: (input: AwsLiteMethodOptions & { PermissionsBoundary: string, RoleName: string }) => Promise<PutRolePermissionsBoundaryResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_PutRolePolicy.html IAM: PutRolePolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#PutRolePolicy IAM: PutRolePolicy}
    */
-  PutRolePolicy: (input: { PolicyDocument: string | Record<string, any>, PolicyName: string, RoleName: string }) => Promise<PutRolePolicyResponse>
+  PutRolePolicy: (input: AwsLiteMethodOptions & { PolicyDocument: string | Record<string, any>, PolicyName: string, RoleName: string }) => Promise<PutRolePolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_PutUserPermissionsBoundary.html IAM: PutUserPermissionsBoundary}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#PutUserPermissionsBoundary IAM: PutUserPermissionsBoundary}
    */
-  PutUserPermissionsBoundary: (input: { PermissionsBoundary: string, UserName: string }) => Promise<PutUserPermissionsBoundaryResponse>
+  PutUserPermissionsBoundary: (input: AwsLiteMethodOptions & { PermissionsBoundary: string, UserName: string }) => Promise<PutUserPermissionsBoundaryResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_PutUserPolicy.html IAM: PutUserPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#PutUserPolicy IAM: PutUserPolicy}
    */
-  PutUserPolicy: (input: { PolicyDocument: string | Record<string, any>, PolicyName: string, UserName: string }) => Promise<PutUserPolicyResponse>
+  PutUserPolicy: (input: AwsLiteMethodOptions & { PolicyDocument: string | Record<string, any>, PolicyName: string, UserName: string }) => Promise<PutUserPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_RemoveClientIDFromOpenIDConnectProvider.html IAM: RemoveClientIDFromOpenIDConnectProvider}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#RemoveClientIDFromOpenIDConnectProvider IAM: RemoveClientIDFromOpenIDConnectProvider}
    */
-  RemoveClientIDFromOpenIDConnectProvider: (input: { ClientID: string, OpenIDConnectProviderArn: string }) => Promise<RemoveClientIDFromOpenIDConnectProviderResponse>
+  RemoveClientIDFromOpenIDConnectProvider: (input: AwsLiteMethodOptions & { ClientID: string, OpenIDConnectProviderArn: string }) => Promise<RemoveClientIDFromOpenIDConnectProviderResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_RemoveRoleFromInstanceProfile.html IAM: RemoveRoleFromInstanceProfile}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#RemoveRoleFromInstanceProfile IAM: RemoveRoleFromInstanceProfile}
    */
-  RemoveRoleFromInstanceProfile: (input: { InstanceProfileName: string, RoleName: string }) => Promise<RemoveRoleFromInstanceProfileResponse>
+  RemoveRoleFromInstanceProfile: (input: AwsLiteMethodOptions & { InstanceProfileName: string, RoleName: string }) => Promise<RemoveRoleFromInstanceProfileResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_RemoveUserFromGroup.html IAM: RemoveUserFromGroup}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#RemoveUserFromGroup IAM: RemoveUserFromGroup}
    */
-  RemoveUserFromGroup: (input: { GroupName: string, UserName: string }) => Promise<RemoveUserFromGroupResponse>
+  RemoveUserFromGroup: (input: AwsLiteMethodOptions & { GroupName: string, UserName: string }) => Promise<RemoveUserFromGroupResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_ResetServiceSpecificCredential.html IAM: ResetServiceSpecificCredential}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#ResetServiceSpecificCredential IAM: ResetServiceSpecificCredential}
    */
-  ResetServiceSpecificCredential: (input: { ServiceSpecificCredentialId: string, UserName?: string }) => Promise<ResetServiceSpecificCredentialResponse>
+  ResetServiceSpecificCredential: (input: AwsLiteMethodOptions & { ServiceSpecificCredentialId: string, UserName?: string }) => Promise<ResetServiceSpecificCredentialResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_SetDefaultPolicyVersion.html IAM: SetDefaultPolicyVersion}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#SetDefaultPolicyVersion IAM: SetDefaultPolicyVersion}
    */
-  SetDefaultPolicyVersion: (input: { PolicyArn: string, VersionId: string }) => Promise<SetDefaultPolicyVersionResponse>
+  SetDefaultPolicyVersion: (input: AwsLiteMethodOptions & { PolicyArn: string, VersionId: string }) => Promise<SetDefaultPolicyVersionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_SetSecurityTokenServicePreferences.html IAM: SetSecurityTokenServicePreferences}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#SetSecurityTokenServicePreferences IAM: SetSecurityTokenServicePreferences}
    */
-  SetSecurityTokenServicePreferences: (input: { GlobalEndpointTokenVersion: string }) => Promise<SetSecurityTokenServicePreferencesResponse>
+  SetSecurityTokenServicePreferences: (input: AwsLiteMethodOptions & { GlobalEndpointTokenVersion: string }) => Promise<SetSecurityTokenServicePreferencesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_SimulateCustomPolicy.html IAM: SimulateCustomPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#SimulateCustomPolicy IAM: SimulateCustomPolicy}
    */
-  SimulateCustomPolicy: (input: { ActionNames: any[], PolicyInputList: any[], CallerArn?: string, ContextEntries?: any[], Marker?: string, MaxItems?: number, PermissionsBoundaryPolicyInputList?: any[], ResourceArns?: any[], ResourceHandlingOption?: string, ResourceOwner?: string, ResourcePolicy?: string | Record<string, any>, paginate?: boolean | string }) => Promise<SimulateCustomPolicyResponse>
+  SimulateCustomPolicy: (input: AwsLiteMethodOptions & { ActionNames: any[], PolicyInputList: any[], CallerArn?: string, ContextEntries?: any[], Marker?: string, MaxItems?: number, PermissionsBoundaryPolicyInputList?: any[], ResourceArns?: any[], ResourceHandlingOption?: string, ResourceOwner?: string, ResourcePolicy?: string | Record<string, any>, paginate?: boolean | string }) => Promise<SimulateCustomPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_SimulatePrincipalPolicy.html IAM: SimulatePrincipalPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#SimulatePrincipalPolicy IAM: SimulatePrincipalPolicy}
    */
-  SimulatePrincipalPolicy: (input: { ActionNames: any[], PolicySourceArn: string, CallerArn?: string, ContextEntries?: any[], Marker?: string, MaxItems?: number, PermissionsBoundaryPolicyInputList?: any[], PolicyInputList?: any[], ResourceArns?: any[], ResourceHandlingOption?: string, ResourceOwner?: string, ResourcePolicy?: string | Record<string, any>, paginate?: boolean | string }) => Promise<SimulatePrincipalPolicyResponse>
+  SimulatePrincipalPolicy: (input: AwsLiteMethodOptions & { ActionNames: any[], PolicySourceArn: string, CallerArn?: string, ContextEntries?: any[], Marker?: string, MaxItems?: number, PermissionsBoundaryPolicyInputList?: any[], PolicyInputList?: any[], ResourceArns?: any[], ResourceHandlingOption?: string, ResourceOwner?: string, ResourcePolicy?: string | Record<string, any>, paginate?: boolean | string }) => Promise<SimulatePrincipalPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_TagInstanceProfile.html IAM: TagInstanceProfile}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#TagInstanceProfile IAM: TagInstanceProfile}
    */
-  TagInstanceProfile: (input: { InstanceProfileName: string, Tags: any[] }) => Promise<TagInstanceProfileResponse>
+  TagInstanceProfile: (input: AwsLiteMethodOptions & { InstanceProfileName: string, Tags: any[] }) => Promise<TagInstanceProfileResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_TagOpenIDConnectProvider.html IAM: TagOpenIDConnectProvider}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#TagOpenIDConnectProvider IAM: TagOpenIDConnectProvider}
    */
-  TagOpenIDConnectProvider: (input: { OpenIDConnectProviderArn: string, Tags: any[] }) => Promise<TagOpenIDConnectProviderResponse>
+  TagOpenIDConnectProvider: (input: AwsLiteMethodOptions & { OpenIDConnectProviderArn: string, Tags: any[] }) => Promise<TagOpenIDConnectProviderResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_TagPolicy.html IAM: TagPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#TagPolicy IAM: TagPolicy}
    */
-  TagPolicy: (input: { PolicyArn: string, Tags: any[] }) => Promise<TagPolicyResponse>
+  TagPolicy: (input: AwsLiteMethodOptions & { PolicyArn: string, Tags: any[] }) => Promise<TagPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_TagRole.html IAM: TagRole}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#TagRole IAM: TagRole}
    */
-  TagRole: (input: { RoleName: string, Tags: any[] }) => Promise<TagRoleResponse>
+  TagRole: (input: AwsLiteMethodOptions & { RoleName: string, Tags: any[] }) => Promise<TagRoleResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_TagServerCertificate.html IAM: TagServerCertificate}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#TagServerCertificate IAM: TagServerCertificate}
    */
-  TagServerCertificate: (input: { ServerCertificateName: string, Tags: any[] }) => Promise<TagServerCertificateResponse>
+  TagServerCertificate: (input: AwsLiteMethodOptions & { ServerCertificateName: string, Tags: any[] }) => Promise<TagServerCertificateResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_TagUser.html IAM: TagUser}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#TagUser IAM: TagUser}
    */
-  TagUser: (input: { UserName: string, Tags: any[] }) => Promise<TagUserResponse>
+  TagUser: (input: AwsLiteMethodOptions & { UserName: string, Tags: any[] }) => Promise<TagUserResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UntagInstanceProfile.html IAM: UntagInstanceProfile}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UntagInstanceProfile IAM: UntagInstanceProfile}
    */
-  UntagInstanceProfile: (input: { InstanceProfileName: string, TagKeys: any[] }) => Promise<UntagInstanceProfileResponse>
+  UntagInstanceProfile: (input: AwsLiteMethodOptions & { InstanceProfileName: string, TagKeys: any[] }) => Promise<UntagInstanceProfileResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UntagOpenIDConnectProvider.html IAM: UntagOpenIDConnectProvider}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UntagOpenIDConnectProvider IAM: UntagOpenIDConnectProvider}
    */
-  UntagOpenIDConnectProvider: (input: { OpenIDConnectProviderArn: string, TagKeys: any[] }) => Promise<UntagOpenIDConnectProviderResponse>
+  UntagOpenIDConnectProvider: (input: AwsLiteMethodOptions & { OpenIDConnectProviderArn: string, TagKeys: any[] }) => Promise<UntagOpenIDConnectProviderResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UntagPolicy.html IAM: UntagPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UntagPolicy IAM: UntagPolicy}
    */
-  UntagPolicy: (input: { PolicyArn: string, TagKeys: any[] }) => Promise<UntagPolicyResponse>
+  UntagPolicy: (input: AwsLiteMethodOptions & { PolicyArn: string, TagKeys: any[] }) => Promise<UntagPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UntagRole.html IAM: UntagRole}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UntagRole IAM: UntagRole}
    */
-  UntagRole: (input: { RoleName: string, TagKeys: any[] }) => Promise<UntagRoleResponse>
+  UntagRole: (input: AwsLiteMethodOptions & { RoleName: string, TagKeys: any[] }) => Promise<UntagRoleResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UntagServerCertificate.html IAM: UntagServerCertificate}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UntagServerCertificate IAM: UntagServerCertificate}
    */
-  UntagServerCertificate: (input: { ServerCertificateName: string, TagKeys: any[] }) => Promise<UntagServerCertificateResponse>
+  UntagServerCertificate: (input: AwsLiteMethodOptions & { ServerCertificateName: string, TagKeys: any[] }) => Promise<UntagServerCertificateResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UntagUser.html IAM: UntagUser}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UntagUser IAM: UntagUser}
    */
-  UntagUser: (input: { UserName: string, TagKeys: any[] }) => Promise<UntagUserResponse>
+  UntagUser: (input: AwsLiteMethodOptions & { UserName: string, TagKeys: any[] }) => Promise<UntagUserResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateAccessKey.html IAM: UpdateAccessKey}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UpdateAccessKey IAM: UpdateAccessKey}
    */
-  UpdateAccessKey: (input: { AccessKeyId: string, Status: string, UserName?: string }) => Promise<UpdateAccessKeyResponse>
+  UpdateAccessKey: (input: AwsLiteMethodOptions & { AccessKeyId: string, Status: string, UserName?: string }) => Promise<UpdateAccessKeyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateAccountPasswordPolicy.html IAM: UpdateAccountPasswordPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UpdateAccountPasswordPolicy IAM: UpdateAccountPasswordPolicy}
    */
-  UpdateAccountPasswordPolicy: (input: { AllowUsersToChangePassword?: boolean, HardExpiry?: boolean, MaxPasswordAge?: number, MinimumPasswordLength?: number, PasswordReusePrevention?: number, RequireLowercaseCharacters?: boolean, RequireNumbers?: boolean, RequireSymbols?: boolean, RequireUppercaseCharacters?: boolean }) => Promise<UpdateAccountPasswordPolicyResponse>
+  UpdateAccountPasswordPolicy: (input: AwsLiteMethodOptions & { AllowUsersToChangePassword?: boolean, HardExpiry?: boolean, MaxPasswordAge?: number, MinimumPasswordLength?: number, PasswordReusePrevention?: number, RequireLowercaseCharacters?: boolean, RequireNumbers?: boolean, RequireSymbols?: boolean, RequireUppercaseCharacters?: boolean }) => Promise<UpdateAccountPasswordPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateAssumeRolePolicy.html IAM: UpdateAssumeRolePolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UpdateAssumeRolePolicy IAM: UpdateAssumeRolePolicy}
    */
-  UpdateAssumeRolePolicy: (input: { PolicyDocument: string | Record<string, any>, RoleName: string }) => Promise<UpdateAssumeRolePolicyResponse>
+  UpdateAssumeRolePolicy: (input: AwsLiteMethodOptions & { PolicyDocument: string | Record<string, any>, RoleName: string }) => Promise<UpdateAssumeRolePolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateGroup.html IAM: UpdateGroup}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UpdateGroup IAM: UpdateGroup}
    */
-  UpdateGroup: (input: { GroupName: string, NewGroupName?: string, NewPath?: string }) => Promise<UpdateGroupResponse>
+  UpdateGroup: (input: AwsLiteMethodOptions & { GroupName: string, NewGroupName?: string, NewPath?: string }) => Promise<UpdateGroupResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateLoginProfile.html IAM: UpdateLoginProfile}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UpdateLoginProfile IAM: UpdateLoginProfile}
    */
-  UpdateLoginProfile: (input: { UserName: string, Password?: string, PasswordResetRequired?: boolean }) => Promise<UpdateLoginProfileResponse>
+  UpdateLoginProfile: (input: AwsLiteMethodOptions & { UserName: string, Password?: string, PasswordResetRequired?: boolean }) => Promise<UpdateLoginProfileResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateOpenIDConnectProviderThumbprint.html IAM: UpdateOpenIDConnectProviderThumbprint}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UpdateOpenIDConnectProviderThumbprint IAM: UpdateOpenIDConnectProviderThumbprint}
    */
-  UpdateOpenIDConnectProviderThumbprint: (input: { OpenIDConnectProviderArn: string, ThumbprintList: any[] }) => Promise<UpdateOpenIDConnectProviderThumbprintResponse>
+  UpdateOpenIDConnectProviderThumbprint: (input: AwsLiteMethodOptions & { OpenIDConnectProviderArn: string, ThumbprintList: any[] }) => Promise<UpdateOpenIDConnectProviderThumbprintResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateRole.html IAM: UpdateRole}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UpdateRole IAM: UpdateRole}
    */
-  UpdateRole: (input: { RoleName: string, Description?: string, MaxSessionDuration?: number }) => Promise<UpdateRoleResponse>
+  UpdateRole: (input: AwsLiteMethodOptions & { RoleName: string, Description?: string, MaxSessionDuration?: number }) => Promise<UpdateRoleResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateRoleDescription.html IAM: UpdateRoleDescription}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UpdateRoleDescription IAM: UpdateRoleDescription}
    */
-  UpdateRoleDescription: (input: { RoleName: string, Description?: string }) => Promise<UpdateRoleDescriptionResponse>
+  UpdateRoleDescription: (input: AwsLiteMethodOptions & { RoleName: string, Description?: string }) => Promise<UpdateRoleDescriptionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateServerCertificate.html IAM: UpdateServerCertificate}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UpdateServerCertificate IAM: UpdateServerCertificate}
    */
-  UpdateServerCertificate: (input: { ServerCertificateName: string, NewPath?: string, NewServerCertificateName?: string }) => Promise<UpdateServerCertificateResponse>
+  UpdateServerCertificate: (input: AwsLiteMethodOptions & { ServerCertificateName: string, NewPath?: string, NewServerCertificateName?: string }) => Promise<UpdateServerCertificateResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateServiceSpecificCredential.html IAM: UpdateServiceSpecificCredential}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UpdateServiceSpecificCredential IAM: UpdateServiceSpecificCredential}
    */
-  UpdateServiceSpecificCredential: (input: { ServiceSpecificCredentialId: string, Status: string, UserName?: string }) => Promise<UpdateServiceSpecificCredentialResponse>
+  UpdateServiceSpecificCredential: (input: AwsLiteMethodOptions & { ServiceSpecificCredentialId: string, Status: string, UserName?: string }) => Promise<UpdateServiceSpecificCredentialResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateSigningCertificate.html IAM: UpdateSigningCertificate}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UpdateSigningCertificate IAM: UpdateSigningCertificate}
    */
-  UpdateSigningCertificate: (input: { CertificateId: string, Status: string, UserName?: string }) => Promise<UpdateSigningCertificateResponse>
+  UpdateSigningCertificate: (input: AwsLiteMethodOptions & { CertificateId: string, Status: string, UserName?: string }) => Promise<UpdateSigningCertificateResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateSSHPublicKey.html IAM: UpdateSSHPublicKey}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UpdateSSHPublicKey IAM: UpdateSSHPublicKey}
    */
-  UpdateSSHPublicKey: (input: { SSHPublicKeyId: string, Status: string, UserName: string }) => Promise<UpdateSSHPublicKeyResponse>
+  UpdateSSHPublicKey: (input: AwsLiteMethodOptions & { SSHPublicKeyId: string, Status: string, UserName: string }) => Promise<UpdateSSHPublicKeyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateUser.html IAM: UpdateUser}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UpdateUser IAM: UpdateUser}
    */
-  UpdateUser: (input: { UserName: string, NewPath?: string, NewUserName?: string }) => Promise<UpdateUserResponse>
+  UpdateUser: (input: AwsLiteMethodOptions & { UserName: string, NewPath?: string, NewUserName?: string }) => Promise<UpdateUserResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UploadServerCertificate.html IAM: UploadServerCertificate}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UploadServerCertificate IAM: UploadServerCertificate}
    */
-  UploadServerCertificate: (input: { CertificateBody: string, PrivateKey: string, ServerCertificateName: string, CertificateChain?: string, Path?: string, Tags?: any[] }) => Promise<UploadServerCertificateResponse>
+  UploadServerCertificate: (input: AwsLiteMethodOptions & { CertificateBody: string, PrivateKey: string, ServerCertificateName: string, CertificateChain?: string, Path?: string, Tags?: any[] }) => Promise<UploadServerCertificateResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UploadSigningCertificate.html IAM: UploadSigningCertificate}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UploadSigningCertificate IAM: UploadSigningCertificate}
    */
-  UploadSigningCertificate: (input: { CertificateBody: string, UserName?: string }) => Promise<UploadSigningCertificateResponse>
+  UploadSigningCertificate: (input: AwsLiteMethodOptions & { CertificateBody: string, UserName?: string }) => Promise<UploadSigningCertificateResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_UploadSSHPublicKey.html IAM: UploadSSHPublicKey}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/iam/readme.md#UploadSSHPublicKey IAM: UploadSSHPublicKey}
    */
-  UploadSSHPublicKey: (input: { SSHPublicKeyBody: string, UserName: string }) => Promise<UploadSSHPublicKeyResponse>
+  UploadSSHPublicKey: (input: AwsLiteMethodOptions & { SSHPublicKeyBody: string, UserName: string }) => Promise<UploadSSHPublicKeyResponse>
   // $METHODS_END
 }
 

--- a/plugins/lambda/types/index.d.ts
+++ b/plugins/lambda/types/index.d.ts
@@ -69,6 +69,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-lambda";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteLambda {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -77,387 +79,387 @@ declare interface AwsLiteLambda {
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_AddLayerVersionPermission.html Lambda: AddLayerVersionPermission}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#AddLayerVersionPermission Lambda: AddLayerVersionPermission}
    */
-  AddLayerVersionPermission: (input: { LayerName: string, RevisionId?: string, VersionNumber: number, Action: string, OrganizationId?: string, Principal?: string, StatementId: string }) => Promise<AddLayerVersionPermissionResponse>
+  AddLayerVersionPermission: (input: AwsLiteMethodOptions & { LayerName: string, RevisionId?: string, VersionNumber: number, Action: string, OrganizationId?: string, Principal?: string, StatementId: string }) => Promise<AddLayerVersionPermissionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html Lambda: AddPermission}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#AddPermission Lambda: AddPermission}
    */
-  AddPermission: (input: { FunctionName: string, Qualifier?: string, Action: string, EventSourceToken?: string, FunctionUrlAuthType?: string, Principal: string, PrincipalOrgID?: string, RevisionId?: string, SourceAccount?: string, SourceArn?: string, StatementId: string }) => Promise<AddPermissionResponse>
+  AddPermission: (input: AwsLiteMethodOptions & { FunctionName: string, Qualifier?: string, Action: string, EventSourceToken?: string, FunctionUrlAuthType?: string, Principal: string, PrincipalOrgID?: string, RevisionId?: string, SourceAccount?: string, SourceArn?: string, StatementId: string }) => Promise<AddPermissionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_CreateAlias.html Lambda: CreateAlias}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#CreateAlias Lambda: CreateAlias}
    */
-  CreateAlias: (input: { FunctionName: string, Description?: string, FunctionVersion: string, Name: string, RoutingConfig?: Record<string, any> }) => Promise<CreateAliasResponse>
+  CreateAlias: (input: AwsLiteMethodOptions & { FunctionName: string, Description?: string, FunctionVersion: string, Name: string, RoutingConfig?: Record<string, any> }) => Promise<CreateAliasResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_CreateCodeSigningConfig.html Lambda: CreateCodeSigningConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#CreateCodeSigningConfig Lambda: CreateCodeSigningConfig}
    */
-  CreateCodeSigningConfig: (input: { AllowedPublishers: Record<string, any>, CodeSigningPolicies?: Record<string, any>, Description?: string }) => Promise<CreateCodeSigningConfigResponse>
+  CreateCodeSigningConfig: (input: AwsLiteMethodOptions & { AllowedPublishers: Record<string, any>, CodeSigningPolicies?: Record<string, any>, Description?: string }) => Promise<CreateCodeSigningConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_CreateEventSourceMapping.html Lambda: CreateEventSourceMapping}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#CreateEventSourceMapping Lambda: CreateEventSourceMapping}
    */
-  CreateEventSourceMapping: (input: { FunctionName: string, AmazonManagedKafkaEventSourceConfig?: Record<string, any>, BatchSize?: number, BisectBatchOnFunctionError?: boolean, DestinationConfig?: Record<string, any>, DocumentDBEventSourceConfig?: Record<string, any>, Enabled?: boolean, EventSourceArn?: string, FilterCriteria?: Record<string, any>, FunctionResponseTypes?: any[], MaximumBatchingWindowInSeconds?: number, MaximumRecordAgeInSeconds?: number, MaximumRetryAttempts?: number, ParallelizationFactor?: number, Queues?: any[], ScalingConfig?: Record<string, any>, SelfManagedEventSource?: Record<string, any>, SelfManagedKafkaEventSourceConfig?: Record<string, any>, SourceAccessConfigurations?: any[], StartingPosition?: string, StartingPositionTimestamp?: Record<string, any>, Topics?: any[], TumblingWindowInSeconds?: number }) => Promise<CreateEventSourceMappingResponse>
+  CreateEventSourceMapping: (input: AwsLiteMethodOptions & { FunctionName: string, AmazonManagedKafkaEventSourceConfig?: Record<string, any>, BatchSize?: number, BisectBatchOnFunctionError?: boolean, DestinationConfig?: Record<string, any>, DocumentDBEventSourceConfig?: Record<string, any>, Enabled?: boolean, EventSourceArn?: string, FilterCriteria?: Record<string, any>, FunctionResponseTypes?: any[], MaximumBatchingWindowInSeconds?: number, MaximumRecordAgeInSeconds?: number, MaximumRetryAttempts?: number, ParallelizationFactor?: number, Queues?: any[], ScalingConfig?: Record<string, any>, SelfManagedEventSource?: Record<string, any>, SelfManagedKafkaEventSourceConfig?: Record<string, any>, SourceAccessConfigurations?: any[], StartingPosition?: string, StartingPositionTimestamp?: Record<string, any>, Topics?: any[], TumblingWindowInSeconds?: number }) => Promise<CreateEventSourceMappingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html Lambda: CreateFunction}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#CreateFunction Lambda: CreateFunction}
    */
-  CreateFunction: (input: { Code: Record<string, any>, FunctionName: string, Role: string, Architectures?: any[], CodeSigningConfigArn?: string, DeadLetterConfig?: Record<string, any>, Description?: string, Environment?: Record<string, any>, EphemeralStorage?: Record<string, any>, FileSystemConfigs?: any[], Handler?: string, ImageConfig?: Record<string, any>, KMSKeyArn?: string, Layers?: any[], MemorySize?: number, PackageType?: string, Publish?: boolean, Runtime?: string, SnapStart?: Record<string, any>, Tags?: any[], Timeout?: number, TracingConfig?: Record<string, any>, VpcConfig?: Record<string, any> }) => Promise<CreateFunctionResponse>
+  CreateFunction: (input: AwsLiteMethodOptions & { Code: Record<string, any>, FunctionName: string, Role: string, Architectures?: any[], CodeSigningConfigArn?: string, DeadLetterConfig?: Record<string, any>, Description?: string, Environment?: Record<string, any>, EphemeralStorage?: Record<string, any>, FileSystemConfigs?: any[], Handler?: string, ImageConfig?: Record<string, any>, KMSKeyArn?: string, Layers?: any[], MemorySize?: number, PackageType?: string, Publish?: boolean, Runtime?: string, SnapStart?: Record<string, any>, Tags?: any[], Timeout?: number, TracingConfig?: Record<string, any>, VpcConfig?: Record<string, any> }) => Promise<CreateFunctionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunctionUrlConfig.html Lambda: CreateFunctionUrlConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#CreateFunctionUrlConfig Lambda: CreateFunctionUrlConfig}
    */
-  CreateFunctionUrlConfig: (input: { AuthType: string, FunctionName: string, Cors?: Record<string, any>, InvokeMode?: string, Qualifier?: string }) => Promise<CreateFunctionUrlConfigResponse>
+  CreateFunctionUrlConfig: (input: AwsLiteMethodOptions & { AuthType: string, FunctionName: string, Cors?: Record<string, any>, InvokeMode?: string, Qualifier?: string }) => Promise<CreateFunctionUrlConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_DeleteAlias.html Lambda: DeleteAlias}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#DeleteAlias Lambda: DeleteAlias}
    */
-  DeleteAlias: (input: { FunctionName: string, Name: string }) => Promise<DeleteAliasResponse>
+  DeleteAlias: (input: AwsLiteMethodOptions & { FunctionName: string, Name: string }) => Promise<DeleteAliasResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_DeleteCodeSigningConfig.html Lambda: DeleteCodeSigningConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#DeleteCodeSigningConfig Lambda: DeleteCodeSigningConfig}
    */
-  DeleteCodeSigningConfig: (input: { CodeSigningConfigArn: string }) => Promise<DeleteCodeSigningConfigResponse>
+  DeleteCodeSigningConfig: (input: AwsLiteMethodOptions & { CodeSigningConfigArn: string }) => Promise<DeleteCodeSigningConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_DeleteEventSourceMapping.html Lambda: DeleteEventSourceMapping}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#DeleteEventSourceMapping Lambda: DeleteEventSourceMapping}
    */
-  DeleteEventSourceMapping: (input: { UUID: string }) => Promise<DeleteEventSourceMappingResponse>
+  DeleteEventSourceMapping: (input: AwsLiteMethodOptions & { UUID: string }) => Promise<DeleteEventSourceMappingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_DeleteFunction.html Lambda: DeleteFunction}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#DeleteFunction Lambda: DeleteFunction}
    */
-  DeleteFunction: (input: { FunctionName: string, Qualifier?: string }) => Promise<DeleteFunctionResponse>
+  DeleteFunction: (input: AwsLiteMethodOptions & { FunctionName: string, Qualifier?: string }) => Promise<DeleteFunctionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_DeleteFunctionCodeSigningConfig.html Lambda: DeleteFunctionCodeSigningConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#DeleteFunctionCodeSigningConfig Lambda: DeleteFunctionCodeSigningConfig}
    */
-  DeleteFunctionCodeSigningConfig: (input: { FunctionName: string }) => Promise<DeleteFunctionCodeSigningConfigResponse>
+  DeleteFunctionCodeSigningConfig: (input: AwsLiteMethodOptions & { FunctionName: string }) => Promise<DeleteFunctionCodeSigningConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_DeleteFunctionConcurrency.html Lambda: DeleteFunctionConcurrency}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#DeleteFunctionConcurrency Lambda: DeleteFunctionConcurrency}
    */
-  DeleteFunctionConcurrency: (input: { FunctionName: string }) => Promise<DeleteFunctionConcurrencyResponse>
+  DeleteFunctionConcurrency: (input: AwsLiteMethodOptions & { FunctionName: string }) => Promise<DeleteFunctionConcurrencyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_DeleteFunctionEventInvokeConfig.html Lambda: DeleteFunctionEventInvokeConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#DeleteFunctionEventInvokeConfig Lambda: DeleteFunctionEventInvokeConfig}
    */
-  DeleteFunctionEventInvokeConfig: (input: { FunctionName: string, Qualifier?: string }) => Promise<DeleteFunctionEventInvokeConfigResponse>
+  DeleteFunctionEventInvokeConfig: (input: AwsLiteMethodOptions & { FunctionName: string, Qualifier?: string }) => Promise<DeleteFunctionEventInvokeConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_DeleteFunctionUrlConfig.html Lambda: DeleteFunctionUrlConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#DeleteFunctionUrlConfig Lambda: DeleteFunctionUrlConfig}
    */
-  DeleteFunctionUrlConfig: (input: { FunctionName: string, Qualifier?: string }) => Promise<DeleteFunctionUrlConfigResponse>
+  DeleteFunctionUrlConfig: (input: AwsLiteMethodOptions & { FunctionName: string, Qualifier?: string }) => Promise<DeleteFunctionUrlConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_DeleteLayerVersion.html Lambda: DeleteLayerVersion}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#DeleteLayerVersion Lambda: DeleteLayerVersion}
    */
-  DeleteLayerVersion: (input: { LayerName: string, VersionNumber: number }) => Promise<DeleteLayerVersionResponse>
+  DeleteLayerVersion: (input: AwsLiteMethodOptions & { LayerName: string, VersionNumber: number }) => Promise<DeleteLayerVersionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_DeleteProvisionedConcurrencyConfig.html Lambda: DeleteProvisionedConcurrencyConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#DeleteProvisionedConcurrencyConfig Lambda: DeleteProvisionedConcurrencyConfig}
    */
-  DeleteProvisionedConcurrencyConfig: (input: { FunctionName: string, Qualifier: string }) => Promise<DeleteProvisionedConcurrencyConfigResponse>
+  DeleteProvisionedConcurrencyConfig: (input: AwsLiteMethodOptions & { FunctionName: string, Qualifier: string }) => Promise<DeleteProvisionedConcurrencyConfigResponse>
   /** @description aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetAccountSettings Lambda: GetAccountSettings} */
-  GetAccountSettings: () => Promise<GetAccountSettingsResponse>
+  GetAccountSettings: (input?: AwsLiteMethodOptions) => Promise<GetAccountSettingsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_GetAlias.html Lambda: GetAlias}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetAlias Lambda: GetAlias}
    */
-  GetAlias: (input: { FunctionName: string, Name: string }) => Promise<GetAliasResponse>
+  GetAlias: (input: AwsLiteMethodOptions & { FunctionName: string, Name: string }) => Promise<GetAliasResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_GetCodeSigningConfig.html Lambda: GetCodeSigningConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetCodeSigningConfig Lambda: GetCodeSigningConfig}
    */
-  GetCodeSigningConfig: (input: { CodeSigningConfigArn: string }) => Promise<GetCodeSigningConfigResponse>
+  GetCodeSigningConfig: (input: AwsLiteMethodOptions & { CodeSigningConfigArn: string }) => Promise<GetCodeSigningConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_GetEventSourceMapping.html Lambda: GetEventSourceMapping}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetEventSourceMapping Lambda: GetEventSourceMapping}
    */
-  GetEventSourceMapping: (input: { UUID: string }) => Promise<GetEventSourceMappingResponse>
+  GetEventSourceMapping: (input: AwsLiteMethodOptions & { UUID: string }) => Promise<GetEventSourceMappingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunction.html Lambda: GetFunction}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetFunction Lambda: GetFunction}
    */
-  GetFunction: (input: { FunctionName: string, Qualifier?: string }) => Promise<GetFunctionResponse>
+  GetFunction: (input: AwsLiteMethodOptions & { FunctionName: string, Qualifier?: string }) => Promise<GetFunctionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunctionCodeSigningConfig.html Lambda: GetFunctionCodeSigningConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetFunctionCodeSigningConfig Lambda: GetFunctionCodeSigningConfig}
    */
-  GetFunctionCodeSigningConfig: (input: { FunctionName: string }) => Promise<GetFunctionCodeSigningConfigResponse>
+  GetFunctionCodeSigningConfig: (input: AwsLiteMethodOptions & { FunctionName: string }) => Promise<GetFunctionCodeSigningConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunctionConcurrency.html Lambda: GetFunctionConcurrency}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetFunctionConcurrency Lambda: GetFunctionConcurrency}
    */
-  GetFunctionConcurrency: (input: { FunctionName: string }) => Promise<GetFunctionConcurrencyResponse>
+  GetFunctionConcurrency: (input: AwsLiteMethodOptions & { FunctionName: string }) => Promise<GetFunctionConcurrencyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunctionConfiguration.html Lambda: GetFunctionConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetFunctionConfiguration Lambda: GetFunctionConfiguration}
    */
-  GetFunctionConfiguration: (input: { FunctionName: string, Qualifier?: string }) => Promise<GetFunctionConfigurationResponse>
+  GetFunctionConfiguration: (input: AwsLiteMethodOptions & { FunctionName: string, Qualifier?: string }) => Promise<GetFunctionConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunctionEventInvokeConfig.html Lambda: GetFunctionEventInvokeConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetFunctionEventInvokeConfig Lambda: GetFunctionEventInvokeConfig}
    */
-  GetFunctionEventInvokeConfig: (input: { FunctionName: string, Qualifier?: string }) => Promise<GetFunctionEventInvokeConfigResponse>
+  GetFunctionEventInvokeConfig: (input: AwsLiteMethodOptions & { FunctionName: string, Qualifier?: string }) => Promise<GetFunctionEventInvokeConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunctionUrlConfig.html Lambda: GetFunctionUrlConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetFunctionUrlConfig Lambda: GetFunctionUrlConfig}
    */
-  GetFunctionUrlConfig: (input: { FunctionName: string, Qualifier?: string }) => Promise<GetFunctionUrlConfigResponse>
+  GetFunctionUrlConfig: (input: AwsLiteMethodOptions & { FunctionName: string, Qualifier?: string }) => Promise<GetFunctionUrlConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_GetLayerVersion.html Lambda: GetLayerVersion}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetLayerVersion Lambda: GetLayerVersion}
    */
-  GetLayerVersion: (input: { LayerName: string, VersionNumber: number }) => Promise<GetLayerVersionResponse>
+  GetLayerVersion: (input: AwsLiteMethodOptions & { LayerName: string, VersionNumber: number }) => Promise<GetLayerVersionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_GetLayerVersionByArn.html Lambda: GetLayerVersionByArn}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetLayerVersionByArn Lambda: GetLayerVersionByArn}
    */
-  GetLayerVersionByArn: (input: { Arn: string }) => Promise<GetLayerVersionByArnResponse>
+  GetLayerVersionByArn: (input: AwsLiteMethodOptions & { Arn: string }) => Promise<GetLayerVersionByArnResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_GetLayerVersionPolicy.html Lambda: GetLayerVersionPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetLayerVersionPolicy Lambda: GetLayerVersionPolicy}
    */
-  GetLayerVersionPolicy: (input: { LayerName: string, VersionNumber: number }) => Promise<GetLayerVersionPolicyResponse>
+  GetLayerVersionPolicy: (input: AwsLiteMethodOptions & { LayerName: string, VersionNumber: number }) => Promise<GetLayerVersionPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_GetPolicy.html Lambda: GetPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetPolicy Lambda: GetPolicy}
    */
-  GetPolicy: (input: { FunctionName: string, Qualifier?: string }) => Promise<GetPolicyResponse>
+  GetPolicy: (input: AwsLiteMethodOptions & { FunctionName: string, Qualifier?: string }) => Promise<GetPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_GetProvisionedConcurrencyConfig.html Lambda: GetProvisionedConcurrencyConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetProvisionedConcurrencyConfig Lambda: GetProvisionedConcurrencyConfig}
    */
-  GetProvisionedConcurrencyConfig: (input: { FunctionName: string, Qualifier: string }) => Promise<GetProvisionedConcurrencyConfigResponse>
+  GetProvisionedConcurrencyConfig: (input: AwsLiteMethodOptions & { FunctionName: string, Qualifier: string }) => Promise<GetProvisionedConcurrencyConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_GetRuntimeManagementConfig.html Lambda: GetRuntimeManagementConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#GetRuntimeManagementConfig Lambda: GetRuntimeManagementConfig}
    */
-  GetRuntimeManagementConfig: (input: { FunctionName: string, Qualifier?: string }) => Promise<GetRuntimeManagementConfigResponse>
+  GetRuntimeManagementConfig: (input: AwsLiteMethodOptions & { FunctionName: string, Qualifier?: string }) => Promise<GetRuntimeManagementConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html Lambda: Invoke}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#Invoke Lambda: Invoke}
    */
-  Invoke: (input: { FunctionName: string, InvocationType?: string, Payload: any[] | Record<string, any>, LogType?: string, ClientContext?: string, Qualifier?: string }) => Promise<InvokeResponse>
+  Invoke: (input: AwsLiteMethodOptions & { FunctionName: string, InvocationType?: string, Payload: any[] | Record<string, any>, LogType?: string, ClientContext?: string, Qualifier?: string }) => Promise<InvokeResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_InvokeAsync.html Lambda: InvokeAsync}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#InvokeAsync Lambda: InvokeAsync}
    */
-  InvokeAsync: (input: { FunctionName: string, InvokeArgs: Record<string, any> }) => Promise<InvokeAsyncResponse>
+  InvokeAsync: (input: AwsLiteMethodOptions & { FunctionName: string, InvokeArgs: Record<string, any> }) => Promise<InvokeAsyncResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_ListAliases.html Lambda: ListAliases}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#ListAliases Lambda: ListAliases}
    */
-  ListAliases: (input: { FunctionName: string, FunctionVersion?: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListAliasesResponse>
+  ListAliases: (input: AwsLiteMethodOptions & { FunctionName: string, FunctionVersion?: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListAliasesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_ListCodeSigningConfigs.html Lambda: ListCodeSigningConfigs}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#ListCodeSigningConfigs Lambda: ListCodeSigningConfigs}
    */
-  ListCodeSigningConfigs: (input: { Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListCodeSigningConfigsResponse>
+  ListCodeSigningConfigs: (input: AwsLiteMethodOptions & { Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListCodeSigningConfigsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_ListEventSourceMappings.html Lambda: ListEventSourceMappings}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#ListEventSourceMappings Lambda: ListEventSourceMappings}
    */
-  ListEventSourceMappings: (input: { EventSourceArn?: string, FunctionName?: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListEventSourceMappingsResponse>
+  ListEventSourceMappings: (input: AwsLiteMethodOptions & { EventSourceArn?: string, FunctionName?: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListEventSourceMappingsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_ListFunctionEventInvokeConfigs.html Lambda: ListFunctionEventInvokeConfigs}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#ListFunctionEventInvokeConfigs Lambda: ListFunctionEventInvokeConfigs}
    */
-  ListFunctionEventInvokeConfigs: (input: { FunctionName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListFunctionEventInvokeConfigsResponse>
+  ListFunctionEventInvokeConfigs: (input: AwsLiteMethodOptions & { FunctionName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListFunctionEventInvokeConfigsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_ListFunctions.html Lambda: ListFunctions}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#ListFunctions Lambda: ListFunctions}
    */
-  ListFunctions: (input: { FunctionVersion?: string, Marker?: string, MasterRegion?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListFunctionsResponse>
+  ListFunctions: (input: AwsLiteMethodOptions & { FunctionVersion?: string, Marker?: string, MasterRegion?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListFunctionsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_ListFunctionsByCodeSigningConfig.html Lambda: ListFunctionsByCodeSigningConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#ListFunctionsByCodeSigningConfig Lambda: ListFunctionsByCodeSigningConfig}
    */
-  ListFunctionsByCodeSigningConfig: (input: { CodeSigningConfigArn: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListFunctionsByCodeSigningConfigResponse>
+  ListFunctionsByCodeSigningConfig: (input: AwsLiteMethodOptions & { CodeSigningConfigArn: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListFunctionsByCodeSigningConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_ListFunctionUrlConfigs.html Lambda: ListFunctionUrlConfigs}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#ListFunctionUrlConfigs Lambda: ListFunctionUrlConfigs}
    */
-  ListFunctionUrlConfigs: (input: { FunctionName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListFunctionUrlConfigsResponse>
+  ListFunctionUrlConfigs: (input: AwsLiteMethodOptions & { FunctionName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListFunctionUrlConfigsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_ListLayers.html Lambda: ListLayers}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#ListLayers Lambda: ListLayers}
    */
-  ListLayers: (input: { CompatibleArchitecture?: string, CompatibleRuntime?: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListLayersResponse>
+  ListLayers: (input: AwsLiteMethodOptions & { CompatibleArchitecture?: string, CompatibleRuntime?: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListLayersResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_ListLayerVersions.html Lambda: ListLayerVersions}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#ListLayerVersions Lambda: ListLayerVersions}
    */
-  ListLayerVersions: (input: { LayerName: string, CompatibleArchitecture?: string, CompatibleRuntime?: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListLayerVersionsResponse>
+  ListLayerVersions: (input: AwsLiteMethodOptions & { LayerName: string, CompatibleArchitecture?: string, CompatibleRuntime?: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListLayerVersionsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_ListProvisionedConcurrencyConfigs.html Lambda: ListProvisionedConcurrencyConfigs}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#ListProvisionedConcurrencyConfigs Lambda: ListProvisionedConcurrencyConfigs}
    */
-  ListProvisionedConcurrencyConfigs: (input: { FunctionName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListProvisionedConcurrencyConfigsResponse>
+  ListProvisionedConcurrencyConfigs: (input: AwsLiteMethodOptions & { FunctionName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListProvisionedConcurrencyConfigsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_ListTags.html Lambda: ListTags}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#ListTags Lambda: ListTags}
    */
-  ListTags: (input: { Resource: string }) => Promise<ListTagsResponse>
+  ListTags: (input: AwsLiteMethodOptions & { Resource: string }) => Promise<ListTagsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_ListVersionsByFunction.html Lambda: ListVersionsByFunction}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#ListVersionsByFunction Lambda: ListVersionsByFunction}
    */
-  ListVersionsByFunction: (input: { FunctionName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListVersionsByFunctionResponse>
+  ListVersionsByFunction: (input: AwsLiteMethodOptions & { FunctionName: string, Marker?: string, MaxItems?: number, paginate?: boolean | string }) => Promise<ListVersionsByFunctionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_PublishLayerVersion.html Lambda: PublishLayerVersion}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#PublishLayerVersion Lambda: PublishLayerVersion}
    */
-  PublishLayerVersion: (input: { Content: Record<string, any>, CompatibleArchitectures?: any[], CompatibleRuntimes?: any[], Description?: string, LiscenceInfo?: string }) => Promise<PublishLayerVersionResponse>
+  PublishLayerVersion: (input: AwsLiteMethodOptions & { Content: Record<string, any>, CompatibleArchitectures?: any[], CompatibleRuntimes?: any[], Description?: string, LiscenceInfo?: string }) => Promise<PublishLayerVersionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_PublishVersion.html Lambda: PublishVersion}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#PublishVersion Lambda: PublishVersion}
    */
-  PublishVersion: (input: { FunctionName: string, CodeSha256?: string, Description?: string, RevisionId?: string }) => Promise<PublishVersionResponse>
+  PublishVersion: (input: AwsLiteMethodOptions & { FunctionName: string, CodeSha256?: string, Description?: string, RevisionId?: string }) => Promise<PublishVersionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_PutFunctionCodeSigningConfig.html Lambda: PutFunctionCodeSigningConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#PutFunctionCodeSigningConfig Lambda: PutFunctionCodeSigningConfig}
    */
-  PutFunctionCodeSigningConfig: (input: { FunctionName: string, CodeSigningConfigArn: string }) => Promise<PutFunctionCodeSigningConfigResponse>
+  PutFunctionCodeSigningConfig: (input: AwsLiteMethodOptions & { FunctionName: string, CodeSigningConfigArn: string }) => Promise<PutFunctionCodeSigningConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_PutFunctionConcurrency.html Lambda: PutFunctionConcurrency}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#PutFunctionConcurrency Lambda: PutFunctionConcurrency}
    */
-  PutFunctionConcurrency: (input: { FunctionName: string, ReservedConcurrentExecutions: number }) => Promise<PutFunctionConcurrencyResponse>
+  PutFunctionConcurrency: (input: AwsLiteMethodOptions & { FunctionName: string, ReservedConcurrentExecutions: number }) => Promise<PutFunctionConcurrencyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_PutFunctionEventInvokeConfig.html Lambda: PutFunctionEventInvokeConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#PutFunctionEventInvokeConfig Lambda: PutFunctionEventInvokeConfig}
    */
-  PutFunctionEventInvokeConfig: (input: { FunctionName: string, DestinationConfig?: Record<string, any>, MaximumEventAgeInSeconds?: number, MaximumRetryAttempts?: number, Qualifier?: string }) => Promise<PutFunctionEventInvokeConfigResponse>
+  PutFunctionEventInvokeConfig: (input: AwsLiteMethodOptions & { FunctionName: string, DestinationConfig?: Record<string, any>, MaximumEventAgeInSeconds?: number, MaximumRetryAttempts?: number, Qualifier?: string }) => Promise<PutFunctionEventInvokeConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_PutProvisionedConcurrencyConfig.html Lambda: PutProvisionedConcurrencyConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#PutProvisionedConcurrencyConfig Lambda: PutProvisionedConcurrencyConfig}
    */
-  PutProvisionedConcurrencyConfig: (input: { FunctionName: string, ProvisionedConcurrentExecutions: number, Qualifier: string }) => Promise<PutProvisionedConcurrencyConfigResponse>
+  PutProvisionedConcurrencyConfig: (input: AwsLiteMethodOptions & { FunctionName: string, ProvisionedConcurrentExecutions: number, Qualifier: string }) => Promise<PutProvisionedConcurrencyConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_PutRuntimeManagementConfig.html Lambda: PutRuntimeManagementConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#PutRuntimeManagementConfig Lambda: PutRuntimeManagementConfig}
    */
-  PutRuntimeManagementConfig: (input: { FunctionName: string, UpdateRuntimeOn: string, Qualifier?: string, RuntimeVersionArn?: string }) => Promise<PutRuntimeManagementConfigResponse>
+  PutRuntimeManagementConfig: (input: AwsLiteMethodOptions & { FunctionName: string, UpdateRuntimeOn: string, Qualifier?: string, RuntimeVersionArn?: string }) => Promise<PutRuntimeManagementConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_RemoveLayerVersionPermission.html Lambda: RemoveLayerVersionPermission}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#RemoveLayerVersionPermission Lambda: RemoveLayerVersionPermission}
    */
-  RemoveLayerVersionPermission: (input: { LayerName: string, StatementId: string, VersionNumber: number, RevisionId?: string }) => Promise<RemoveLayerVersionPermissionResponse>
+  RemoveLayerVersionPermission: (input: AwsLiteMethodOptions & { LayerName: string, StatementId: string, VersionNumber: number, RevisionId?: string }) => Promise<RemoveLayerVersionPermissionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_RemovePermission.html Lambda: RemovePermission}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#RemovePermission Lambda: RemovePermission}
    */
-  RemovePermission: (input: { FunctionName: string, StatementId: string, RevisionId?: string, Qualifier?: string }) => Promise<RemovePermissionResponse>
+  RemovePermission: (input: AwsLiteMethodOptions & { FunctionName: string, StatementId: string, RevisionId?: string, Qualifier?: string }) => Promise<RemovePermissionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_TagResource.html Lambda: TagResource}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#TagResource Lambda: TagResource}
    */
-  TagResource: (input: { Resource: string, Tags: Record<string, any> }) => Promise<TagResourceResponse>
+  TagResource: (input: AwsLiteMethodOptions & { Resource: string, Tags: Record<string, any> }) => Promise<TagResourceResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_UntagResource.html Lambda: UntagResource}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#UntagResource Lambda: UntagResource}
    */
-  UntagResource: (input: { Resource: string, TagKeys: any[] }) => Promise<UntagResourceResponse>
+  UntagResource: (input: AwsLiteMethodOptions & { Resource: string, TagKeys: any[] }) => Promise<UntagResourceResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_UpdateAlias.html Lambda: UpdateAlias}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#UpdateAlias Lambda: UpdateAlias}
    */
-  UpdateAlias: (input: { FunctionName: string, Name: string, Description?: string, FunctionVersion?: string, RevisionId?: string, RoutingConfig?: Record<string, any> }) => Promise<UpdateAliasResponse>
+  UpdateAlias: (input: AwsLiteMethodOptions & { FunctionName: string, Name: string, Description?: string, FunctionVersion?: string, RevisionId?: string, RoutingConfig?: Record<string, any> }) => Promise<UpdateAliasResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_UpdateCodeSigningConfig.html Lambda: UpdateCodeSigningConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#UpdateCodeSigningConfig Lambda: UpdateCodeSigningConfig}
    */
-  UpdateCodeSigningConfig: (input: { CodeSigningConfigArn: string, AllowedPublishers?: Record<string, any>, CodeSigningPolicies?: Record<string, any>, Description?: string }) => Promise<UpdateCodeSigningConfigResponse>
+  UpdateCodeSigningConfig: (input: AwsLiteMethodOptions & { CodeSigningConfigArn: string, AllowedPublishers?: Record<string, any>, CodeSigningPolicies?: Record<string, any>, Description?: string }) => Promise<UpdateCodeSigningConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_UpdateEventSourceMapping.html Lambda: UpdateEventSourceMapping}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#UpdateEventSourceMapping Lambda: UpdateEventSourceMapping}
    */
-  UpdateEventSourceMapping: (input: { UUID: string, AmazonManagedKafkaEventSourceConfig?: Record<string, any>, BatchSize?: number, BisectBatchOnFunctionError?: boolean, DestinationConfig?: Record<string, any>, DocumentDBEventSourceConfig?: Record<string, any>, Enabled?: boolean, FilterCriteria?: Record<string, any>, FunctionName?: string, FunctionResponseTypes?: any[], MaximumBatchingWindowInSeconds?: number, MaximumRecordAgeInSeconds?: number, MaximumRetryAttempts?: number, ParallelizationFactor?: number, Queues?: any[], ScalingConfig?: Record<string, any>, SourceAccessConfigurations?: any[], TumblingWindowInSeconds?: number }) => Promise<UpdateEventSourceMappingResponse>
+  UpdateEventSourceMapping: (input: AwsLiteMethodOptions & { UUID: string, AmazonManagedKafkaEventSourceConfig?: Record<string, any>, BatchSize?: number, BisectBatchOnFunctionError?: boolean, DestinationConfig?: Record<string, any>, DocumentDBEventSourceConfig?: Record<string, any>, Enabled?: boolean, FilterCriteria?: Record<string, any>, FunctionName?: string, FunctionResponseTypes?: any[], MaximumBatchingWindowInSeconds?: number, MaximumRecordAgeInSeconds?: number, MaximumRetryAttempts?: number, ParallelizationFactor?: number, Queues?: any[], ScalingConfig?: Record<string, any>, SourceAccessConfigurations?: any[], TumblingWindowInSeconds?: number }) => Promise<UpdateEventSourceMappingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_UpdateFunctionCode.html Lambda: UpdateFunctionCode}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#UpdateFunctionCode Lambda: UpdateFunctionCode}
    */
-  UpdateFunctionCode: (input: { FunctionName: string, Architectures?: any[], DryRun?: string, ImageUri?: string, Publish?: boolean, RevisionId?: string, S3Bucket?: string, S3Key?: string, S3ObjectVersion?: string, ZipFile?: string | Buffer }) => Promise<UpdateFunctionCodeResponse>
+  UpdateFunctionCode: (input: AwsLiteMethodOptions & { FunctionName: string, Architectures?: any[], DryRun?: string, ImageUri?: string, Publish?: boolean, RevisionId?: string, S3Bucket?: string, S3Key?: string, S3ObjectVersion?: string, ZipFile?: string | Buffer }) => Promise<UpdateFunctionCodeResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_UpdateFunctionConfiguration.html Lambda: UpdateFunctionConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#UpdateFunctionConfiguration Lambda: UpdateFunctionConfiguration}
    */
-  UpdateFunctionConfiguration: (input: { FunctionName: string, DeadLetterConfig?: Record<string, any>, Description?: string, Environment?: Record<string, any>, EphemeralStorage?: Record<string, any>, FileSystemConfigs?: any[], Handler?: string, ImageConfig?: Record<string, any>, KMSKeyArn?: string, Layers?: any[], MemorySize?: number, RevisionId?: string, Role?: string, Runtime?: string, SnapStart?: Record<string, any>, Timeout?: number, TracingConfig?: Record<string, any>, VpcConfig?: Record<string, any> }) => Promise<UpdateFunctionConfigurationResponse>
+  UpdateFunctionConfiguration: (input: AwsLiteMethodOptions & { FunctionName: string, DeadLetterConfig?: Record<string, any>, Description?: string, Environment?: Record<string, any>, EphemeralStorage?: Record<string, any>, FileSystemConfigs?: any[], Handler?: string, ImageConfig?: Record<string, any>, KMSKeyArn?: string, Layers?: any[], MemorySize?: number, RevisionId?: string, Role?: string, Runtime?: string, SnapStart?: Record<string, any>, Timeout?: number, TracingConfig?: Record<string, any>, VpcConfig?: Record<string, any> }) => Promise<UpdateFunctionConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_UpdateFunctionEventInvokeConfig.html Lambda: UpdateFunctionEventInvokeConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#UpdateFunctionEventInvokeConfig Lambda: UpdateFunctionEventInvokeConfig}
    */
-  UpdateFunctionEventInvokeConfig: (input: { FunctionName: string, DestinationConfig?: Record<string, any>, MaximumEventAgeInSeconds?: number, MaximumRetryAttempts?: number }) => Promise<UpdateFunctionEventInvokeConfigResponse>
+  UpdateFunctionEventInvokeConfig: (input: AwsLiteMethodOptions & { FunctionName: string, DestinationConfig?: Record<string, any>, MaximumEventAgeInSeconds?: number, MaximumRetryAttempts?: number }) => Promise<UpdateFunctionEventInvokeConfigResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/lambda/latest/dg/API_UpdateFunctionUrlConfig.html Lambda: UpdateFunctionUrlConfig}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/lambda/readme.md#UpdateFunctionUrlConfig Lambda: UpdateFunctionUrlConfig}
    */
-  UpdateFunctionUrlConfig: (input: { FunctionName: string, AuthType?: string, Cors?: Record<string, any>, InvokeMode?: string, Qualifier?: string }) => Promise<UpdateFunctionUrlConfigResponse>
+  UpdateFunctionUrlConfig: (input: AwsLiteMethodOptions & { FunctionName: string, AuthType?: string, Cors?: Record<string, any>, InvokeMode?: string, Qualifier?: string }) => Promise<UpdateFunctionUrlConfigResponse>
   // $METHODS_END
 }
 

--- a/plugins/organizations/types/index.d.ts
+++ b/plugins/organizations/types/index.d.ts
@@ -5,6 +5,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-organizations";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteOrganizations {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -13,7 +15,7 @@ declare interface AwsLiteOrganizations {
    * - AWS docs: {@link https://docs.aws.amazon.com/organizations/latest/APIReference/API_ListAccounts.html Organizations: ListAccounts}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/organizations/readme.md#ListAccounts Organizations: ListAccounts}
    */
-  ListAccounts: (input: { MaxResults?: number, NextToken?: string, paginate?: boolean | string }) => Promise<ListAccountsResponse>
+  ListAccounts: (input: AwsLiteMethodOptions & { MaxResults?: number, NextToken?: string, paginate?: boolean | string }) => Promise<ListAccountsResponse>
   // $METHODS_END
 }
 

--- a/plugins/rds-data/types/index.d.ts
+++ b/plugins/rds-data/types/index.d.ts
@@ -10,6 +10,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-rds-data";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteRDSData {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -18,33 +20,33 @@ declare interface AwsLiteRDSData {
    * - AWS docs: {@link https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_BatchExecuteStatement.html RDS Data Service: BatchExecuteStatement}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/rds-data/readme.md#BatchExecuteStatement RDS Data Service: BatchExecuteStatement}
    */
-  BatchExecuteStatement: (input: { database?: string, parameterSets?: any[], resourceArn: string, schema?: string, secretArn: string, sql: string, transactionId?: string }) => Promise<BatchExecuteStatementResponse>
+  BatchExecuteStatement: (input: AwsLiteMethodOptions & { database?: string, parameterSets?: any[], resourceArn: string, schema?: string, secretArn: string, sql: string, transactionId?: string }) => Promise<BatchExecuteStatementResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_BeginTransaction.html RDS Data Service: BeginTransaction}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/rds-data/readme.md#BeginTransaction RDS Data Service: BeginTransaction}
    */
-  BeginTransaction: (input: { database?: string, resourceArn: string, schema?: string, secretArn: string }) => Promise<BeginTransactionResponse>
+  BeginTransaction: (input: AwsLiteMethodOptions & { database?: string, resourceArn: string, schema?: string, secretArn: string }) => Promise<BeginTransactionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_CommitTransaction.html RDS Data Service: CommitTransaction}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/rds-data/readme.md#CommitTransaction RDS Data Service: CommitTransaction}
    */
-  CommitTransaction: (input: { resourceArn: string, secretArn: string, transactionId: string }) => Promise<CommitTransactionResponse>
+  CommitTransaction: (input: AwsLiteMethodOptions & { resourceArn: string, secretArn: string, transactionId: string }) => Promise<CommitTransactionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_ExecuteStatement.html RDS Data Service: ExecuteStatement}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/rds-data/readme.md#ExecuteStatement RDS Data Service: ExecuteStatement}
    */
-  ExecuteStatement: (input: { continueAfterTimeout?: boolean, database?: string, formatRecordsAs?: string, includeResultMetadata?: boolean, parameters?: any[], resourceArn: string, resultSetOptions?: Record<string, any>, schema?: string, secretArn: string, sql: string, transactionId?: string }) => Promise<ExecuteStatementResponse>
+  ExecuteStatement: (input: AwsLiteMethodOptions & { continueAfterTimeout?: boolean, database?: string, formatRecordsAs?: string, includeResultMetadata?: boolean, parameters?: any[], resourceArn: string, resultSetOptions?: Record<string, any>, schema?: string, secretArn: string, sql: string, transactionId?: string }) => Promise<ExecuteStatementResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_RollbackTransaction.html RDS Data Service: RollbackTransaction}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/rds-data/readme.md#RollbackTransaction RDS Data Service: RollbackTransaction}
    */
-  RollbackTransaction: (input: { resourceArn: string, secretArn: string, transactionId: string }) => Promise<RollbackTransactionResponse>
+  RollbackTransaction: (input: AwsLiteMethodOptions & { resourceArn: string, secretArn: string, transactionId: string }) => Promise<RollbackTransactionResponse>
   /** @description aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/rds-data/readme.md#ExecuteSql RDS Data Service: ExecuteSql} */
-  ExecuteSql: () => Promise<ExecuteSqlResponse>
+  ExecuteSql: (input?: AwsLiteMethodOptions) => Promise<ExecuteSqlResponse>
   // $METHODS_END
 }
 

--- a/plugins/route53/types/index.d.ts
+++ b/plugins/route53/types/index.d.ts
@@ -6,6 +6,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-route-53";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteRoute53 {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -14,13 +16,13 @@ declare interface AwsLiteRoute53 {
    * - AWS docs: {@link https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html Route 53: ChangeResourceRecordSets}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/route53/readme.md#ChangeResourceRecordSets Route 53: ChangeResourceRecordSets}
    */
-  ChangeResourceRecordSets: (input: { HostedZoneId: string, ChangeBatch?: Record<string, any> }) => Promise<ChangeResourceRecordSetsResponse>
+  ChangeResourceRecordSets: (input: AwsLiteMethodOptions & { HostedZoneId: string, ChangeBatch?: Record<string, any> }) => Promise<ChangeResourceRecordSetsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListResourceRecordSets.html Route 53: ListResourceRecordSets}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/route53/readme.md#ListResourceRecordSets Route 53: ListResourceRecordSets}
    */
-  ListResourceRecordSets: (input: { HostedZoneId: string, MaxItems?: number, StartRecordIdentifier?: string, StartRecordName?: string, StartRecordType?: string, paginate?: boolean | string }) => Promise<ListResourceRecordSetsResponse>
+  ListResourceRecordSets: (input: AwsLiteMethodOptions & { HostedZoneId: string, MaxItems?: number, StartRecordIdentifier?: string, StartRecordName?: string, StartRecordType?: string, paginate?: boolean | string }) => Promise<ListResourceRecordSetsResponse>
   // $METHODS_END
 }
 

--- a/plugins/s3/types/index.d.ts
+++ b/plugins/s3/types/index.d.ts
@@ -91,6 +91,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-s3";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteS3 {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -99,518 +101,518 @@ declare interface AwsLiteS3 {
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html S3: AbortMultipartUpload}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#AbortMultipartUpload S3: AbortMultipartUpload}
    */
-  AbortMultipartUpload: (input: { Bucket: string, Key: string, UploadId: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<AbortMultipartUploadResponse>
+  AbortMultipartUpload: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, UploadId: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<AbortMultipartUploadResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html S3: CompleteMultipartUpload}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#CompleteMultipartUpload S3: CompleteMultipartUpload}
    */
-  CompleteMultipartUpload: (input: { Bucket: string, Key: string, UploadId: string, MultipartUpload?: Record<string, any>, ChecksumCRC32?: string, ChecksumCRC32C?: string, ChecksumSHA1?: string, ChecksumSHA256?: string, RequestPayer?: string, ExpectedBucketOwner?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string }) => Promise<CompleteMultipartUploadResponse>
+  CompleteMultipartUpload: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, UploadId: string, MultipartUpload?: Record<string, any>, ChecksumCRC32?: string, ChecksumCRC32C?: string, ChecksumSHA1?: string, ChecksumSHA256?: string, RequestPayer?: string, ExpectedBucketOwner?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string }) => Promise<CompleteMultipartUploadResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html S3: CopyObject}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#CopyObject S3: CopyObject}
    */
-  CopyObject: (input: { Bucket: string, Key: string, ACL?: string, CacheControl?: string, ChecksumAlgorithm?: string, ContentDisposition?: string, ContentEncoding?: string, ContentLanguage?: string, ContentType?: string, CopySource?: string, CopySourceIfMatch?: string, CopySourceIfModifiedSince?: string, CopySourceIfNoneMatch?: string, CopySourceIfUnmodifiedSince?: string, Expires?: string, GrantFullControl?: string, GrantRead?: string, GrantReadACP?: string, GrantWriteACP?: string, MetadataDirective?: string, TaggingDirective?: string, ServerSideEncryption?: string, StorageClass?: string, WebsiteRedirectLocation?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string, SSEKMSKeyId?: string, SSEKMSEncryptionContext?: string, BucketKeyEnabled?: string, CopySourceSSECustomerAlgorithm?: string, CopySourceSSECustomerKey?: string, CopySourceSSECustomerKeyMD5?: string, RequestPayer?: string, Tagging?: string, ObjectLockMode?: string, ObjectLockRetainUntilDate?: string, ObjectLockLegalHoldStatus?: string, ExpectedBucketOwner?: string, ExpectedSourceBucketOwner?: string }) => Promise<CopyObjectResponse>
+  CopyObject: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, ACL?: string, CacheControl?: string, ChecksumAlgorithm?: string, ContentDisposition?: string, ContentEncoding?: string, ContentLanguage?: string, ContentType?: string, CopySource?: string, CopySourceIfMatch?: string, CopySourceIfModifiedSince?: string, CopySourceIfNoneMatch?: string, CopySourceIfUnmodifiedSince?: string, Expires?: string, GrantFullControl?: string, GrantRead?: string, GrantReadACP?: string, GrantWriteACP?: string, MetadataDirective?: string, TaggingDirective?: string, ServerSideEncryption?: string, StorageClass?: string, WebsiteRedirectLocation?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string, SSEKMSKeyId?: string, SSEKMSEncryptionContext?: string, BucketKeyEnabled?: string, CopySourceSSECustomerAlgorithm?: string, CopySourceSSECustomerKey?: string, CopySourceSSECustomerKeyMD5?: string, RequestPayer?: string, Tagging?: string, ObjectLockMode?: string, ObjectLockRetainUntilDate?: string, ObjectLockLegalHoldStatus?: string, ExpectedBucketOwner?: string, ExpectedSourceBucketOwner?: string }) => Promise<CopyObjectResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html S3: CreateBucket}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#CreateBucket S3: CreateBucket}
    */
-  CreateBucket: (input: { Bucket: string, CreateBucketConfiguration?: Record<string, any>, ACL?: string, GrantFullControl?: string, GrantRead?: string, GrantReadACP?: string, GrantWrite?: string, GrantWriteACP?: string, ObjectLockEnabledForBucket?: string, ObjectOwnership?: string }) => Promise<CreateBucketResponse>
+  CreateBucket: (input: AwsLiteMethodOptions & { Bucket: string, CreateBucketConfiguration?: Record<string, any>, ACL?: string, GrantFullControl?: string, GrantRead?: string, GrantReadACP?: string, GrantWrite?: string, GrantWriteACP?: string, ObjectLockEnabledForBucket?: string, ObjectOwnership?: string }) => Promise<CreateBucketResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html S3: CreateMultipartUpload}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#CreateMultipartUpload S3: CreateMultipartUpload}
    */
-  CreateMultipartUpload: (input: { Bucket: string, Key: string, ACL?: string, CacheControl?: string, ContentDisposition?: string, ContentEncoding?: string, ContentLanguage?: string, ContentType?: string, Expires?: string, GrantFullControl?: string, GrantRead?: string, GrantReadACP?: string, GrantWriteACP?: string, ServerSideEncryption?: string, StorageClass?: string, WebsiteRedirectLocation?: string, SSECustomerAlgorithm?: string, SSECustomerKeyMD5?: string, SSEKMSKeyId?: string, SSEKMSEncryptionContext?: string, BucketKeyEnabled?: string, RequestPayer?: string, Tagging?: string, ObjectLockMode?: string, ObjectLockRetainUntilDate?: string, ObjectLockLegalHoldStatus?: string, ExpectedBucketOwner?: string, ChecksumAlgorithm?: string }) => Promise<CreateMultipartUploadResponse>
+  CreateMultipartUpload: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, ACL?: string, CacheControl?: string, ContentDisposition?: string, ContentEncoding?: string, ContentLanguage?: string, ContentType?: string, Expires?: string, GrantFullControl?: string, GrantRead?: string, GrantReadACP?: string, GrantWriteACP?: string, ServerSideEncryption?: string, StorageClass?: string, WebsiteRedirectLocation?: string, SSECustomerAlgorithm?: string, SSECustomerKeyMD5?: string, SSEKMSKeyId?: string, SSEKMSEncryptionContext?: string, BucketKeyEnabled?: string, RequestPayer?: string, Tagging?: string, ObjectLockMode?: string, ObjectLockRetainUntilDate?: string, ObjectLockLegalHoldStatus?: string, ExpectedBucketOwner?: string, ChecksumAlgorithm?: string }) => Promise<CreateMultipartUploadResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html S3: DeleteBucket}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteBucket S3: DeleteBucket}
    */
-  DeleteBucket: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketResponse>
+  DeleteBucket: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketAnalyticsConfiguration.html S3: DeleteBucketAnalyticsConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteBucketAnalyticsConfiguration S3: DeleteBucketAnalyticsConfiguration}
    */
-  DeleteBucketAnalyticsConfiguration: (input: { Bucket: string, Id: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketAnalyticsConfigurationResponse>
+  DeleteBucketAnalyticsConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, Id: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketAnalyticsConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketCors.html S3: DeleteBucketCors}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteBucketCors S3: DeleteBucketCors}
    */
-  DeleteBucketCors: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketCorsResponse>
+  DeleteBucketCors: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketCorsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketEncryption.html S3: DeleteBucketEncryption}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteBucketEncryption S3: DeleteBucketEncryption}
    */
-  DeleteBucketEncryption: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketEncryptionResponse>
+  DeleteBucketEncryption: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketEncryptionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketIntelligentTieringConfiguration.html S3: DeleteBucketIntelligentTieringConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteBucketIntelligentTieringConfiguration S3: DeleteBucketIntelligentTieringConfiguration}
    */
-  DeleteBucketIntelligentTieringConfiguration: (input: { Bucket: string, Id: string }) => Promise<DeleteBucketIntelligentTieringConfigurationResponse>
+  DeleteBucketIntelligentTieringConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, Id: string }) => Promise<DeleteBucketIntelligentTieringConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketInventoryConfiguration.html S3: DeleteBucketInventoryConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteBucketInventoryConfiguration S3: DeleteBucketInventoryConfiguration}
    */
-  DeleteBucketInventoryConfiguration: (input: { Bucket: string, Id: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketInventoryConfigurationResponse>
+  DeleteBucketInventoryConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, Id: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketInventoryConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketLifecycle.html S3: DeleteBucketLifecycle}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteBucketLifecycle S3: DeleteBucketLifecycle}
    */
-  DeleteBucketLifecycle: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketLifecycleResponse>
+  DeleteBucketLifecycle: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketLifecycleResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetricsConfiguration.html S3: DeleteBucketMetricsConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteBucketMetricsConfiguration S3: DeleteBucketMetricsConfiguration}
    */
-  DeleteBucketMetricsConfiguration: (input: { Bucket: string, Id: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketMetricsConfigurationResponse>
+  DeleteBucketMetricsConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, Id: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketMetricsConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketOwnershipControls.html S3: DeleteBucketOwnershipControls}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteBucketOwnershipControls S3: DeleteBucketOwnershipControls}
    */
-  DeleteBucketOwnershipControls: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketOwnershipControlsResponse>
+  DeleteBucketOwnershipControls: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketOwnershipControlsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketPolicy.html S3: DeleteBucketPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteBucketPolicy S3: DeleteBucketPolicy}
    */
-  DeleteBucketPolicy: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketPolicyResponse>
+  DeleteBucketPolicy: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketReplication.html S3: DeleteBucketReplication}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteBucketReplication S3: DeleteBucketReplication}
    */
-  DeleteBucketReplication: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketReplicationResponse>
+  DeleteBucketReplication: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketReplicationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketTagging.html S3: DeleteBucketTagging}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteBucketTagging S3: DeleteBucketTagging}
    */
-  DeleteBucketTagging: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketTaggingResponse>
+  DeleteBucketTagging: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketTaggingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketWebsite.html S3: DeleteBucketWebsite}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteBucketWebsite S3: DeleteBucketWebsite}
    */
-  DeleteBucketWebsite: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketWebsiteResponse>
+  DeleteBucketWebsite: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeleteBucketWebsiteResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html S3: DeleteObject}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteObject S3: DeleteObject}
    */
-  DeleteObject: (input: { Bucket: string, Key: string, VersionId?: string, MFA?: string, RequestPayer?: string, BypassGovernanceRetention?: string, ExpectedBucketOwner?: string }) => Promise<DeleteObjectResponse>
+  DeleteObject: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, VersionId?: string, MFA?: string, RequestPayer?: string, BypassGovernanceRetention?: string, ExpectedBucketOwner?: string }) => Promise<DeleteObjectResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html S3: DeleteObjects}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteObjects S3: DeleteObjects}
    */
-  DeleteObjects: (input: { Bucket: string, Delete: Record<string, any>, MFA?: string, RequestPayer?: string, BypassGovernanceRetention?: string, ExpectedBucketOwner?: string, ChecksumAlgorithm?: string, ContentMD5?: string }) => Promise<DeleteObjectsResponse>
+  DeleteObjects: (input: AwsLiteMethodOptions & { Bucket: string, Delete: Record<string, any>, MFA?: string, RequestPayer?: string, BypassGovernanceRetention?: string, ExpectedBucketOwner?: string, ChecksumAlgorithm?: string, ContentMD5?: string }) => Promise<DeleteObjectsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectTagging.html S3: DeleteObjectTagging}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeleteObjectTagging S3: DeleteObjectTagging}
    */
-  DeleteObjectTagging: (input: { Bucket: string, Key: string, VersionId?: string, ExpectedBucketOwner?: string }) => Promise<DeleteObjectTaggingResponse>
+  DeleteObjectTagging: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, VersionId?: string, ExpectedBucketOwner?: string }) => Promise<DeleteObjectTaggingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletePublicAccessBlock.html S3: DeletePublicAccessBlock}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#DeletePublicAccessBlock S3: DeletePublicAccessBlock}
    */
-  DeletePublicAccessBlock: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeletePublicAccessBlockResponse>
+  DeletePublicAccessBlock: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<DeletePublicAccessBlockResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAccelerateConfiguration.html S3: GetBucketAccelerateConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketAccelerateConfiguration S3: GetBucketAccelerateConfiguration}
    */
-  GetBucketAccelerateConfiguration: (input: { Bucket: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<GetBucketAccelerateConfigurationResponse>
+  GetBucketAccelerateConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<GetBucketAccelerateConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAcl.html S3: GetBucketAcl}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketAcl S3: GetBucketAcl}
    */
-  GetBucketAcl: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketAclResponse>
+  GetBucketAcl: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketAclResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAnalyticsConfiguration.html S3: GetBucketAnalyticsConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketAnalyticsConfiguration S3: GetBucketAnalyticsConfiguration}
    */
-  GetBucketAnalyticsConfiguration: (input: { Bucket: string, Id: string, ExpectedBucketOwner?: string }) => Promise<GetBucketAnalyticsConfigurationResponse>
+  GetBucketAnalyticsConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, Id: string, ExpectedBucketOwner?: string }) => Promise<GetBucketAnalyticsConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketCors.html S3: GetBucketCors}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketCors S3: GetBucketCors}
    */
-  GetBucketCors: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketCorsResponse>
+  GetBucketCors: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketCorsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketEncryption.html S3: GetBucketEncryption}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketEncryption S3: GetBucketEncryption}
    */
-  GetBucketEncryption: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketEncryptionResponse>
+  GetBucketEncryption: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketEncryptionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketIntelligentTieringConfiguration.html S3: GetBucketIntelligentTieringConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketIntelligentTieringConfiguration S3: GetBucketIntelligentTieringConfiguration}
    */
-  GetBucketIntelligentTieringConfiguration: (input: { Bucket: string, Id: string }) => Promise<GetBucketIntelligentTieringConfigurationResponse>
+  GetBucketIntelligentTieringConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, Id: string }) => Promise<GetBucketIntelligentTieringConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketInventoryConfiguration.html S3: GetBucketInventoryConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketInventoryConfiguration S3: GetBucketInventoryConfiguration}
    */
-  GetBucketInventoryConfiguration: (input: { Bucket: string, Id: string, ExpectedBucketOwner?: string }) => Promise<GetBucketInventoryConfigurationResponse>
+  GetBucketInventoryConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, Id: string, ExpectedBucketOwner?: string }) => Promise<GetBucketInventoryConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycle.html S3: GetBucketLifecycleConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketLifecycleConfiguration S3: GetBucketLifecycleConfiguration}
    */
-  GetBucketLifecycleConfiguration: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketLifecycleConfigurationResponse>
+  GetBucketLifecycleConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketLifecycleConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html S3: GetBucketLocation}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketLocation S3: GetBucketLocation}
    */
-  GetBucketLocation: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketLocationResponse>
+  GetBucketLocation: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketLocationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLogging.html S3: GetBucketLogging}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketLogging S3: GetBucketLogging}
    */
-  GetBucketLogging: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketLoggingResponse>
+  GetBucketLogging: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketLoggingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetricsConfiguration.html S3: GetBucketMetricsConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketMetricsConfiguration S3: GetBucketMetricsConfiguration}
    */
-  GetBucketMetricsConfiguration: (input: { Bucket: string, Id: string, ExpectedBucketOwner?: string }) => Promise<GetBucketMetricsConfigurationResponse>
+  GetBucketMetricsConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, Id: string, ExpectedBucketOwner?: string }) => Promise<GetBucketMetricsConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketNotificationConfiguration.html S3: GetBucketNotificationConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketNotificationConfiguration S3: GetBucketNotificationConfiguration}
    */
-  GetBucketNotificationConfiguration: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketNotificationConfigurationResponse>
+  GetBucketNotificationConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketNotificationConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketOwnershipControls.html S3: GetBucketOwnershipControls}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketOwnershipControls S3: GetBucketOwnershipControls}
    */
-  GetBucketOwnershipControls: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketOwnershipControlsResponse>
+  GetBucketOwnershipControls: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketOwnershipControlsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketPolicy.html S3: GetBucketPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketPolicy S3: GetBucketPolicy}
    */
-  GetBucketPolicy: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketPolicyResponse>
+  GetBucketPolicy: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketPolicyStatus.html S3: GetBucketPolicyStatus}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketPolicyStatus S3: GetBucketPolicyStatus}
    */
-  GetBucketPolicyStatus: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketPolicyStatusResponse>
+  GetBucketPolicyStatus: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketPolicyStatusResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketReplication.html S3: GetBucketReplication}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketReplication S3: GetBucketReplication}
    */
-  GetBucketReplication: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketReplicationResponse>
+  GetBucketReplication: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketReplicationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketRequestPayment.html S3: GetBucketRequestPayment}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketRequestPayment S3: GetBucketRequestPayment}
    */
-  GetBucketRequestPayment: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketRequestPaymentResponse>
+  GetBucketRequestPayment: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketRequestPaymentResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html S3: GetBucketTagging}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketTagging S3: GetBucketTagging}
    */
-  GetBucketTagging: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketTaggingResponse>
+  GetBucketTagging: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketTaggingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html S3: GetBucketVersioning}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketVersioning S3: GetBucketVersioning}
    */
-  GetBucketVersioning: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketVersioningResponse>
+  GetBucketVersioning: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketVersioningResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketWebsite.html S3: GetBucketWebsite}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetBucketWebsite S3: GetBucketWebsite}
    */
-  GetBucketWebsite: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketWebsiteResponse>
+  GetBucketWebsite: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetBucketWebsiteResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html S3: GetObject}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetObject S3: GetObject}
    */
-  GetObject: (input: { Bucket: string, Key: string, PartNumber?: number, VersionId?: string, IfMatch?: string, IfModifiedSince?: string, IfNoneMatch?: string, IfUnmodifiedSince?: string, Range?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string, RequestPayer?: string, ExpectedBucketOwner?: string, ChecksumMode?: string, ResponseCacheControl?: string, ResponseContentDisposition?: string, ResponseContentEncoding?: string, ResponseContentLanguage?: string, ResponseContentType?: string, ResponseExpires?: string, rawResponsePayload?: boolean, streamResponsePayload?: boolean }) => Promise<GetObjectResponse>
+  GetObject: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, PartNumber?: number, VersionId?: string, IfMatch?: string, IfModifiedSince?: string, IfNoneMatch?: string, IfUnmodifiedSince?: string, Range?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string, RequestPayer?: string, ExpectedBucketOwner?: string, ChecksumMode?: string, ResponseCacheControl?: string, ResponseContentDisposition?: string, ResponseContentEncoding?: string, ResponseContentLanguage?: string, ResponseContentType?: string, ResponseExpires?: string, rawResponsePayload?: boolean, streamResponsePayload?: boolean }) => Promise<GetObjectResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html S3: GetObjectAcl}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetObjectAcl S3: GetObjectAcl}
    */
-  GetObjectAcl: (input: { Bucket: string, Key: string, VersionId?: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<GetObjectAclResponse>
+  GetObjectAcl: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, VersionId?: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<GetObjectAclResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAttributes.html S3: GetObjectAttributes}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetObjectAttributes S3: GetObjectAttributes}
    */
-  GetObjectAttributes: (input: { Bucket: string, Key: string, ObjectAttributes: any[], VersionId?: string, MaxParts?: number, PartNumberMarker?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string, RequestPayer?: string, ExpectedBucketOwner?: string }) => Promise<GetObjectAttributesResponse>
+  GetObjectAttributes: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, ObjectAttributes: any[], VersionId?: string, MaxParts?: number, PartNumberMarker?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string, RequestPayer?: string, ExpectedBucketOwner?: string }) => Promise<GetObjectAttributesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectLegalHold.html S3: GetObjectLegalHold}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetObjectLegalHold S3: GetObjectLegalHold}
    */
-  GetObjectLegalHold: (input: { Bucket: string, Key: string, VersionId?: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<GetObjectLegalHoldResponse>
+  GetObjectLegalHold: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, VersionId?: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<GetObjectLegalHoldResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectLockConfiguration.html S3: GetObjectLockConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetObjectLockConfiguration S3: GetObjectLockConfiguration}
    */
-  GetObjectLockConfiguration: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetObjectLockConfigurationResponse>
+  GetObjectLockConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetObjectLockConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectRetention.html S3: GetObjectRetention}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetObjectRetention S3: GetObjectRetention}
    */
-  GetObjectRetention: (input: { Bucket: string, Key: string, VersionId?: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<GetObjectRetentionResponse>
+  GetObjectRetention: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, VersionId?: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<GetObjectRetentionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html S3: GetObjectTagging}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetObjectTagging S3: GetObjectTagging}
    */
-  GetObjectTagging: (input: { Bucket: string, Key: string, VersionId?: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<GetObjectTaggingResponse>
+  GetObjectTagging: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, VersionId?: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<GetObjectTaggingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTorrent.html S3: GetObjectTorrent}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetObjectTorrent S3: GetObjectTorrent}
    */
-  GetObjectTorrent: (input: { Bucket: string, Key: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<GetObjectTorrentResponse>
+  GetObjectTorrent: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<GetObjectTorrentResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html S3: GetPublicAccessBlock}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#GetPublicAccessBlock S3: GetPublicAccessBlock}
    */
-  GetPublicAccessBlock: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetPublicAccessBlockResponse>
+  GetPublicAccessBlock: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<GetPublicAccessBlockResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html S3: HeadBucket}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#HeadBucket S3: HeadBucket}
    */
-  HeadBucket: (input: { Bucket: string, ExpectedBucketOwner?: string }) => Promise<HeadBucketResponse>
+  HeadBucket: (input: AwsLiteMethodOptions & { Bucket: string, ExpectedBucketOwner?: string }) => Promise<HeadBucketResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html S3: HeadObject}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#HeadObject S3: HeadObject}
    */
-  HeadObject: (input: { Bucket: string, Key: string, PartNumber?: number, VersionId?: string, IfMatch?: string, IfModifiedSince?: string, IfNoneMatch?: string, IfUnmodifiedSince?: string, Range?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string, RequestPayer?: string, ExpectedBucketOwner?: string, ChecksumMode?: string }) => Promise<HeadObjectResponse>
+  HeadObject: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, PartNumber?: number, VersionId?: string, IfMatch?: string, IfModifiedSince?: string, IfNoneMatch?: string, IfUnmodifiedSince?: string, Range?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string, RequestPayer?: string, ExpectedBucketOwner?: string, ChecksumMode?: string }) => Promise<HeadObjectResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketAnalyticsConfigurations.html S3: ListBucketAnalyticsConfigurations}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#ListBucketAnalyticsConfigurations S3: ListBucketAnalyticsConfigurations}
    */
-  ListBucketAnalyticsConfigurations: (input: { Bucket: string, ContinuationToken?: string, paginate?: boolean | string, ExpectedBucketOwner?: string }) => Promise<ListBucketAnalyticsConfigurationsResponse>
+  ListBucketAnalyticsConfigurations: (input: AwsLiteMethodOptions & { Bucket: string, ContinuationToken?: string, paginate?: boolean | string, ExpectedBucketOwner?: string }) => Promise<ListBucketAnalyticsConfigurationsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html S3: ListBucketIntelligentTieringConfigurations}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#ListBucketIntelligentTieringConfigurations S3: ListBucketIntelligentTieringConfigurations}
    */
-  ListBucketIntelligentTieringConfigurations: (input: { Bucket: string, ContinuationToken?: string, paginate?: boolean | string, ExpectedBucketOwner?: string }) => Promise<ListBucketIntelligentTieringConfigurationsResponse>
+  ListBucketIntelligentTieringConfigurations: (input: AwsLiteMethodOptions & { Bucket: string, ContinuationToken?: string, paginate?: boolean | string, ExpectedBucketOwner?: string }) => Promise<ListBucketIntelligentTieringConfigurationsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketInventoryConfigurations.html S3: ListBucketInventoryConfigurations}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#ListBucketInventoryConfigurations S3: ListBucketInventoryConfigurations}
    */
-  ListBucketInventoryConfigurations: (input: { Bucket: string, ContinuationToken?: string, paginate?: boolean | string, ExpectedBucketOwner?: string }) => Promise<ListBucketInventoryConfigurationsResponse>
+  ListBucketInventoryConfigurations: (input: AwsLiteMethodOptions & { Bucket: string, ContinuationToken?: string, paginate?: boolean | string, ExpectedBucketOwner?: string }) => Promise<ListBucketInventoryConfigurationsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketMetricsConfigurations.html S3: ListBucketMetricsConfigurations}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#ListBucketMetricsConfigurations S3: ListBucketMetricsConfigurations}
    */
-  ListBucketMetricsConfigurations: (input: { Bucket: string, ContinuationToken?: string, paginate?: boolean | string, ExpectedBucketOwner?: string }) => Promise<ListBucketMetricsConfigurationsResponse>
+  ListBucketMetricsConfigurations: (input: AwsLiteMethodOptions & { Bucket: string, ContinuationToken?: string, paginate?: boolean | string, ExpectedBucketOwner?: string }) => Promise<ListBucketMetricsConfigurationsResponse>
   /** @description aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#ListBuckets S3: ListBuckets} */
-  ListBuckets: () => Promise<ListBucketsResponse>
+  ListBuckets: (input?: AwsLiteMethodOptions) => Promise<ListBucketsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html S3: ListMultipartUploads}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#ListMultipartUploads S3: ListMultipartUploads}
    */
-  ListMultipartUploads: (input: { Bucket: string, Delimiter?: string, EncodingType?: string, KeyMarker?: string, MaxUploads?: number, UploadIdMarker?: string, ExpectedBucketOwner?: string, RequestPayer?: string, paginate?: boolean | string }) => Promise<ListMultipartUploadsResponse>
+  ListMultipartUploads: (input: AwsLiteMethodOptions & { Bucket: string, Delimiter?: string, EncodingType?: string, KeyMarker?: string, MaxUploads?: number, UploadIdMarker?: string, ExpectedBucketOwner?: string, RequestPayer?: string, paginate?: boolean | string }) => Promise<ListMultipartUploadsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html S3: ListObjectsV2}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#ListObjectsV2 S3: ListObjectsV2}
    */
-  ListObjectsV2: (input: { Bucket: string, ContinuationToken?: string, Delimiter?: string, EncodingType?: string, FetchOwner?: string, MaxKeys?: number, Prefix?: string, StartAfter?: string, RequestPayer?: string, ExpectedBucketOwner?: string, OptionalObjectAttributes?: string, paginate?: boolean | string }) => Promise<ListObjectsV2Response>
+  ListObjectsV2: (input: AwsLiteMethodOptions & { Bucket: string, ContinuationToken?: string, Delimiter?: string, EncodingType?: string, FetchOwner?: string, MaxKeys?: number, Prefix?: string, StartAfter?: string, RequestPayer?: string, ExpectedBucketOwner?: string, OptionalObjectAttributes?: string, paginate?: boolean | string }) => Promise<ListObjectsV2Response>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html S3: ListObjectVersions}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#ListObjectVersions S3: ListObjectVersions}
    */
-  ListObjectVersions: (input: { Bucket: string, Delimiter?: string, EncodingType?: string, KeyMarker?: string, MaxKeys?: number, Prefix?: string, VersionIdMarker?: string, paginate?: boolean | string, ExpectedBucketOwner?: string, RequestPayer?: string, OptionalObjectAttributes?: string }) => Promise<ListObjectVersionsResponse>
+  ListObjectVersions: (input: AwsLiteMethodOptions & { Bucket: string, Delimiter?: string, EncodingType?: string, KeyMarker?: string, MaxKeys?: number, Prefix?: string, VersionIdMarker?: string, paginate?: boolean | string, ExpectedBucketOwner?: string, RequestPayer?: string, OptionalObjectAttributes?: string }) => Promise<ListObjectVersionsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html S3: ListParts}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#ListParts S3: ListParts}
    */
-  ListParts: (input: { Bucket: string, Key: string, UploadId: string, MaxParts?: number, PartNumberMarker?: string, paginate?: boolean | string, RequestPayer?: string, ExpectedBucketOwner?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string }) => Promise<ListPartsResponse>
+  ListParts: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, UploadId: string, MaxParts?: number, PartNumberMarker?: string, paginate?: boolean | string, RequestPayer?: string, ExpectedBucketOwner?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string }) => Promise<ListPartsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAccelerateConfiguration.html S3: PutBucketAccelerateConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketAccelerateConfiguration S3: PutBucketAccelerateConfiguration}
    */
-  PutBucketAccelerateConfiguration: (input: { AccelerateConfiguration: Record<string, any>, Bucket: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketAccelerateConfigurationResponse>
+  PutBucketAccelerateConfiguration: (input: AwsLiteMethodOptions & { AccelerateConfiguration: Record<string, any>, Bucket: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketAccelerateConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAnalyticsConfiguration.html S3: PutBucketAnalyticsConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketAnalyticsConfiguration S3: PutBucketAnalyticsConfiguration}
    */
-  PutBucketAnalyticsConfiguration: (input: { Bucket: string, Id: string, AnalyticsConfiguration: Record<string, any>, ExpectedBucketOwner?: string }) => Promise<PutBucketAnalyticsConfigurationResponse>
+  PutBucketAnalyticsConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, Id: string, AnalyticsConfiguration: Record<string, any>, ExpectedBucketOwner?: string }) => Promise<PutBucketAnalyticsConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketCors.html S3: PutBucketCors}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketCors S3: PutBucketCors}
    */
-  PutBucketCors: (input: { Bucket: string, CORSConfiguration: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketCorsResponse>
+  PutBucketCors: (input: AwsLiteMethodOptions & { Bucket: string, CORSConfiguration: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketCorsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html S3: PutBucketEncryption}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketEncryption S3: PutBucketEncryption}
    */
-  PutBucketEncryption: (input: { Bucket: string, ServerSideEncryptionConfiguration: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketEncryptionResponse>
+  PutBucketEncryption: (input: AwsLiteMethodOptions & { Bucket: string, ServerSideEncryptionConfiguration: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketEncryptionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html S3: PutBucketIntelligentTieringConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketIntelligentTieringConfiguration S3: PutBucketIntelligentTieringConfiguration}
    */
-  PutBucketIntelligentTieringConfiguration: (input: { Bucket: string, Id: string, IntelligentTieringConfiguration: Record<string, any> }) => Promise<PutBucketIntelligentTieringConfigurationResponse>
+  PutBucketIntelligentTieringConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, Id: string, IntelligentTieringConfiguration: Record<string, any> }) => Promise<PutBucketIntelligentTieringConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html S3: PutBucketInventoryConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketInventoryConfiguration S3: PutBucketInventoryConfiguration}
    */
-  PutBucketInventoryConfiguration: (input: { Bucket: string, Id: string, InventoryConfiguration: Record<string, any>, ExpectedBucketOwner?: string }) => Promise<PutBucketInventoryConfigurationResponse>
+  PutBucketInventoryConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, Id: string, InventoryConfiguration: Record<string, any>, ExpectedBucketOwner?: string }) => Promise<PutBucketInventoryConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html S3: PutBucketLifecycleConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketLifecycleConfiguration S3: PutBucketLifecycleConfiguration}
    */
-  PutBucketLifecycleConfiguration: (input: { Bucket: string, LifecycleConfiguration: Record<string, any>, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string, ContentMD5?: string }) => Promise<PutBucketLifecycleConfigurationResponse>
+  PutBucketLifecycleConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, LifecycleConfiguration: Record<string, any>, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string, ContentMD5?: string }) => Promise<PutBucketLifecycleConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html S3: PutBucketMetricsConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketMetricsConfiguration S3: PutBucketMetricsConfiguration}
    */
-  PutBucketMetricsConfiguration: (input: { Bucket: string, Id: string, MetricsConfiguration: Record<string, any>, ExpectedBucketOwner?: string }) => Promise<PutBucketMetricsConfigurationResponse>
+  PutBucketMetricsConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, Id: string, MetricsConfiguration: Record<string, any>, ExpectedBucketOwner?: string }) => Promise<PutBucketMetricsConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketNotificationConfiguration.html S3: PutBucketNotificationConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketNotificationConfiguration S3: PutBucketNotificationConfiguration}
    */
-  PutBucketNotificationConfiguration: (input: { Bucket: string, NotificationConfiguration: Record<string, any>, ExpectedBucketOwner?: string }) => Promise<PutBucketNotificationConfigurationResponse>
+  PutBucketNotificationConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, NotificationConfiguration: Record<string, any>, ExpectedBucketOwner?: string }) => Promise<PutBucketNotificationConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketOwnershipControls.html S3: PutBucketOwnershipControls}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketOwnershipControls S3: PutBucketOwnershipControls}
    */
-  PutBucketOwnershipControls: (input: { Bucket: string, OwnershipControls: Record<string, any>, ContentMD5?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketOwnershipControlsResponse>
+  PutBucketOwnershipControls: (input: AwsLiteMethodOptions & { Bucket: string, OwnershipControls: Record<string, any>, ContentMD5?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketOwnershipControlsResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketPolicy.html S3: PutBucketPolicy}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketPolicy S3: PutBucketPolicy}
    */
-  PutBucketPolicy: (input: { Bucket: string, Policy: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ConfirmRemoveSelfBucketAccess?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketPolicyResponse>
+  PutBucketPolicy: (input: AwsLiteMethodOptions & { Bucket: string, Policy: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ConfirmRemoveSelfBucketAccess?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketPolicyResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html S3: PutBucketReplication}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketReplication S3: PutBucketReplication}
    */
-  PutBucketReplication: (input: { Bucket: string, ReplicationConfiguration: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, Token?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketReplicationResponse>
+  PutBucketReplication: (input: AwsLiteMethodOptions & { Bucket: string, ReplicationConfiguration: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, Token?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketReplicationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketRequestPayment.html S3: PutBucketRequestPayment}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketRequestPayment S3: PutBucketRequestPayment}
    */
-  PutBucketRequestPayment: (input: { Bucket: string, RequestPaymentConfiguration: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketRequestPaymentResponse>
+  PutBucketRequestPayment: (input: AwsLiteMethodOptions & { Bucket: string, RequestPaymentConfiguration: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketRequestPaymentResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketTagging.html S3: PutBucketTagging}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketTagging S3: PutBucketTagging}
    */
-  PutBucketTagging: (input: { Bucket: string, Tagging: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketTaggingResponse>
+  PutBucketTagging: (input: AwsLiteMethodOptions & { Bucket: string, Tagging: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketTaggingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html S3: PutBucketVersioning}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketVersioning S3: PutBucketVersioning}
    */
-  PutBucketVersioning: (input: { Bucket: string, VersioningConfiguration: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, MFA?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketVersioningResponse>
+  PutBucketVersioning: (input: AwsLiteMethodOptions & { Bucket: string, VersioningConfiguration: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, MFA?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketVersioningResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketWebsite.html S3: PutBucketWebsite}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutBucketWebsite S3: PutBucketWebsite}
    */
-  PutBucketWebsite: (input: { Bucket: string, WebsiteConfiguration: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketWebsiteResponse>
+  PutBucketWebsite: (input: AwsLiteMethodOptions & { Bucket: string, WebsiteConfiguration: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutBucketWebsiteResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html S3: PutObject}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutObject S3: PutObject}
    */
-  PutObject: (input: { Bucket: string, Key: string, Body?: Buffer | stream | string, File?: string, ApplyChecksum?: boolean, MinChunkSize?: number, ACL?: string, BucketKeyEnabled?: string, CacheControl?: string, ChecksumAlgorithm?: string, ChecksumCRC32?: string, ChecksumCRC32C?: string, ChecksumSHA1?: string, ChecksumSHA256?: string, ContentDisposition?: string, ContentEncoding?: string, ContentLanguage?: string, ContentLength?: string, ContentMD5?: string, ContentType?: string, ExpectedBucketOwner?: string, Expires?: string, GrantFullControl?: string, GrantRead?: string, GrantReadACP?: string, GrantWriteACP?: string, ObjectLockLegalHoldStatus?: string, ObjectLockMode?: string, ObjectLockRetainUntilDate?: string, RequestPayer?: string, ServerSideEncryption?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string, SSEKMSEncryptionContext?: string, SSEKMSKeyId?: string, StorageClass?: string, Tagging?: string, WebsiteRedirectLocation?: string, Metadata?: Record<string, any> }) => Promise<PutObjectResponse>
+  PutObject: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, Body?: Buffer | stream | string, File?: string, ApplyChecksum?: boolean, MinChunkSize?: number, ACL?: string, BucketKeyEnabled?: string, CacheControl?: string, ChecksumAlgorithm?: string, ChecksumCRC32?: string, ChecksumCRC32C?: string, ChecksumSHA1?: string, ChecksumSHA256?: string, ContentDisposition?: string, ContentEncoding?: string, ContentLanguage?: string, ContentLength?: string, ContentMD5?: string, ContentType?: string, ExpectedBucketOwner?: string, Expires?: string, GrantFullControl?: string, GrantRead?: string, GrantReadACP?: string, GrantWriteACP?: string, ObjectLockLegalHoldStatus?: string, ObjectLockMode?: string, ObjectLockRetainUntilDate?: string, RequestPayer?: string, ServerSideEncryption?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string, SSEKMSEncryptionContext?: string, SSEKMSKeyId?: string, StorageClass?: string, Tagging?: string, WebsiteRedirectLocation?: string, Metadata?: Record<string, any> }) => Promise<PutObjectResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLegalHold.html S3: PutObjectLegalHold}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutObjectLegalHold S3: PutObjectLegalHold}
    */
-  PutObjectLegalHold: (input: { Bucket: string, Key: string, VersionId?: string, LegalHold: Record<string, any>, RequestPayer?: string, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutObjectLegalHoldResponse>
+  PutObjectLegalHold: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, VersionId?: string, LegalHold: Record<string, any>, RequestPayer?: string, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutObjectLegalHoldResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLockConfiguration.html S3: PutObjectLockConfiguration}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutObjectLockConfiguration S3: PutObjectLockConfiguration}
    */
-  PutObjectLockConfiguration: (input: { Bucket: string, ObjectLockConfiguration: Record<string, any>, RequestPayer?: string, Token?: string, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutObjectLockConfigurationResponse>
+  PutObjectLockConfiguration: (input: AwsLiteMethodOptions & { Bucket: string, ObjectLockConfiguration: Record<string, any>, RequestPayer?: string, Token?: string, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutObjectLockConfigurationResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectRetention.html S3: PutObjectRetention}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutObjectRetention S3: PutObjectRetention}
    */
-  PutObjectRetention: (input: { Bucket: string, Key: string, VersionId?: string, Retention: Record<string, any>, RequestPayer?: string, BypassGovernanceRetention?: string, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutObjectRetentionResponse>
+  PutObjectRetention: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, VersionId?: string, Retention: Record<string, any>, RequestPayer?: string, BypassGovernanceRetention?: string, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutObjectRetentionResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectTagging.html S3: PutObjectTagging}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutObjectTagging S3: PutObjectTagging}
    */
-  PutObjectTagging: (input: { Bucket: string, Key: string, VersionId?: string, Tagging: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<PutObjectTaggingResponse>
+  PutObjectTagging: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, VersionId?: string, Tagging: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string, RequestPayer?: string }) => Promise<PutObjectTaggingResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutPublicAccessBlock.html S3: PutPublicAccessBlock}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#PutPublicAccessBlock S3: PutPublicAccessBlock}
    */
-  PutPublicAccessBlock: (input: { Bucket: string, PublicAccessBlockConfiguration: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutPublicAccessBlockResponse>
+  PutPublicAccessBlock: (input: AwsLiteMethodOptions & { Bucket: string, PublicAccessBlockConfiguration: Record<string, any>, ContentMD5?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<PutPublicAccessBlockResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html S3: RestoreObject}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#RestoreObject S3: RestoreObject}
    */
-  RestoreObject: (input: { Bucket: string, Key: string, RestoreRequest: Record<string, any>, VersionId?: string, RequestPayer?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<RestoreObjectResponse>
+  RestoreObject: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, RestoreRequest: Record<string, any>, VersionId?: string, RequestPayer?: string, ChecksumAlgorithm?: string, ExpectedBucketOwner?: string }) => Promise<RestoreObjectResponse>
   /**
    * @description
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#Upload S3: Upload}
    */
-  Upload: (input: { Bucket: string, Key: string, Body?: Buffer | stream | string, File?: string, ChunkSize?: number, Concurrency?: number, ACL?: string, BucketKeyEnabled?: string, CacheControl?: string, ChecksumAlgorithm?: string, ChecksumCRC32?: string, ChecksumCRC32C?: string, ChecksumSHA1?: string, ChecksumSHA256?: string, ContentDisposition?: string, ContentEncoding?: string, ContentLanguage?: string, ContentType?: string, ExpectedBucketOwner?: string, Expires?: string, GrantFullControl?: string, GrantRead?: string, GrantReadACP?: string, GrantWriteACP?: string, ObjectLockLegalHoldStatus?: string, ObjectLockMode?: string, ObjectLockRetainUntilDate?: string, RequestPayer?: string, ServerSideEncryption?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string, SSEKMSEncryptionContext?: string, SSEKMSKeyId?: string, StorageClass?: string, Tagging?: string, WebsiteRedirectLocation?: string, Metadata?: Record<string, any> }) => Promise<UploadResponse>
+  Upload: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, Body?: Buffer | stream | string, File?: string, ChunkSize?: number, Concurrency?: number, ACL?: string, BucketKeyEnabled?: string, CacheControl?: string, ChecksumAlgorithm?: string, ChecksumCRC32?: string, ChecksumCRC32C?: string, ChecksumSHA1?: string, ChecksumSHA256?: string, ContentDisposition?: string, ContentEncoding?: string, ContentLanguage?: string, ContentType?: string, ExpectedBucketOwner?: string, Expires?: string, GrantFullControl?: string, GrantRead?: string, GrantReadACP?: string, GrantWriteACP?: string, ObjectLockLegalHoldStatus?: string, ObjectLockMode?: string, ObjectLockRetainUntilDate?: string, RequestPayer?: string, ServerSideEncryption?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string, SSEKMSEncryptionContext?: string, SSEKMSKeyId?: string, StorageClass?: string, Tagging?: string, WebsiteRedirectLocation?: string, Metadata?: Record<string, any> }) => Promise<UploadResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html S3: UploadPart}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/s3/readme.md#UploadPart S3: UploadPart}
    */
-  UploadPart: (input: { Bucket: string, Key: string, PartNumber?: number, Body?: Buffer | stream | string, ContentLength?: string, ContentMD5?: string, ChecksumAlgorithm?: string, ChecksumCRC32?: string, ChecksumCRC32C?: string, ChecksumSHA1?: string, ChecksumSHA256?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string, RequestPayer?: string, ExpectedBucketOwner?: string }) => Promise<UploadPartResponse>
+  UploadPart: (input: AwsLiteMethodOptions & { Bucket: string, Key: string, PartNumber?: number, Body?: Buffer | stream | string, ContentLength?: string, ContentMD5?: string, ChecksumAlgorithm?: string, ChecksumCRC32?: string, ChecksumCRC32C?: string, ChecksumSHA1?: string, ChecksumSHA256?: string, SSECustomerAlgorithm?: string, SSECustomerKey?: string, SSECustomerKeyMD5?: string, RequestPayer?: string, ExpectedBucketOwner?: string }) => Promise<UploadPartResponse>
   // $METHODS_END
 }
 

--- a/plugins/sns/types/index.d.ts
+++ b/plugins/sns/types/index.d.ts
@@ -5,6 +5,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-sns";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteSNS {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -13,7 +15,7 @@ declare interface AwsLiteSNS {
    * - AWS docs: {@link https://docs.aws.amazon.com/sns/latest/api/API_Publish.html SNS: Publish}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/sns/readme.md#Publish SNS: Publish}
    */
-  Publish: (input: { Message: string, MessageAttributes?: string, MessageDeduplicationId?: string, MessageGroupId?: string, MessageStructure?: string, PhoneNumber?: string, Subject?: string, TargetArn?: string, TopicArn?: string }) => Promise<PublishResponse>
+  Publish: (input: AwsLiteMethodOptions & { Message: string, MessageAttributes?: string, MessageDeduplicationId?: string, MessageGroupId?: string, MessageStructure?: string, PhoneNumber?: string, Subject?: string, TargetArn?: string, TopicArn?: string }) => Promise<PublishResponse>
   // $METHODS_END
 }
 

--- a/plugins/sqs/types/index.d.ts
+++ b/plugins/sqs/types/index.d.ts
@@ -8,6 +8,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-sqs";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteSQS {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -16,25 +18,25 @@ declare interface AwsLiteSQS {
    * - AWS docs: {@link https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html SQS: SendMessage}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/sqs/readme.md#SendMessage SQS: SendMessage}
    */
-  SendMessage: (input: { MessageBody: string, QueueUrl: string, DelaySeconds?: number, MessageAttributes?: Record<string, any>, MessageDeduplicationId?: string, MessageGroupId?: string, MessageSystemAttributes?: Record<string, any> }) => Promise<SendMessageResponse>
+  SendMessage: (input: AwsLiteMethodOptions & { MessageBody: string, QueueUrl: string, DelaySeconds?: number, MessageAttributes?: Record<string, any>, MessageDeduplicationId?: string, MessageGroupId?: string, MessageSystemAttributes?: Record<string, any> }) => Promise<SendMessageResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueAttributes.html SQS: GetQueueAttributes}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/sqs/readme.md#GetQueueAttributes SQS: GetQueueAttributes}
    */
-  GetQueueAttributes: (input: { QueueUrl: string, AttributeNames?: any[] }) => Promise<GetQueueAttributesResponse>
+  GetQueueAttributes: (input: AwsLiteMethodOptions & { QueueUrl: string, AttributeNames?: any[] }) => Promise<GetQueueAttributesResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html SQS: ReceiveMessage}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/sqs/readme.md#ReceiveMessage SQS: ReceiveMessage}
    */
-  ReceiveMessage: (input: { QueueUrl: string, AttributeNames?: any[], MaxNumberOfMessages?: number, MessageAttributeNames?: any[], MessageSystemAttributeNames?: any[], ReceiveRequestAttemptId?: string, VisibilityTimeout?: number, WaitTimeSeconds?: number }) => Promise<ReceiveMessageResponse>
+  ReceiveMessage: (input: AwsLiteMethodOptions & { QueueUrl: string, AttributeNames?: any[], MaxNumberOfMessages?: number, MessageAttributeNames?: any[], MessageSystemAttributeNames?: any[], ReceiveRequestAttemptId?: string, VisibilityTimeout?: number, WaitTimeSeconds?: number }) => Promise<ReceiveMessageResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessage.html SQS: DeleteMessage}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/sqs/readme.md#DeleteMessage SQS: DeleteMessage}
    */
-  DeleteMessage: (input: { QueueUrl: string, ReceiptHandle: string }) => Promise<DeleteMessageResponse>
+  DeleteMessage: (input: AwsLiteMethodOptions & { QueueUrl: string, ReceiptHandle: string }) => Promise<DeleteMessageResponse>
   // $METHODS_END
 }
 

--- a/plugins/ssm/types/index.d.ts
+++ b/plugins/ssm/types/index.d.ts
@@ -10,6 +10,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-ssm";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteSSM {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -18,37 +20,37 @@ declare interface AwsLiteSSM {
    * - AWS docs: {@link https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DeleteParameter SSM: DeleteParameter}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/ssm/readme.md#DeleteParameter SSM: DeleteParameter}
    */
-  DeleteParameter: (input: { Name: string }) => Promise<DeleteParameterResponse>
+  DeleteParameter: (input: AwsLiteMethodOptions & { Name: string }) => Promise<DeleteParameterResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DeleteParameters SSM: DeleteParameters}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/ssm/readme.md#DeleteParameters SSM: DeleteParameters}
    */
-  DeleteParameters: (input: { Names: any[] }) => Promise<DeleteParametersResponse>
+  DeleteParameters: (input: AwsLiteMethodOptions & { Names: any[] }) => Promise<DeleteParametersResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameter.html SSM: GetParameter}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/ssm/readme.md#GetParameter SSM: GetParameter}
    */
-  GetParameter: (input: { Name: string, WithDecryption?: boolean }) => Promise<GetParameterResponse>
+  GetParameter: (input: AwsLiteMethodOptions & { Name: string, WithDecryption?: boolean }) => Promise<GetParameterResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameters.html SSM: GetParameters}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/ssm/readme.md#GetParameters SSM: GetParameters}
    */
-  GetParameters: (input: { Names: any[], WithDecryption?: boolean }) => Promise<GetParametersResponse>
+  GetParameters: (input: AwsLiteMethodOptions & { Names: any[], WithDecryption?: boolean }) => Promise<GetParametersResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParametersByPath SSM: GetParametersByPath}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/ssm/readme.md#GetParametersByPath SSM: GetParametersByPath}
    */
-  GetParametersByPath: (input: { Path: string, MaxResults?: number, NextToken?: string, ParameterFilters?: any[], Recursive?: boolean, WithDecryption?: boolean, paginate?: boolean }) => Promise<GetParametersByPathResponse>
+  GetParametersByPath: (input: AwsLiteMethodOptions & { Path: string, MaxResults?: number, NextToken?: string, ParameterFilters?: any[], Recursive?: boolean, WithDecryption?: boolean, paginate?: boolean }) => Promise<GetParametersByPathResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_PutParameter SSM: PutParameter}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/ssm/readme.md#PutParameter SSM: PutParameter}
    */
-  PutParameter: (input: { Name: string, Value: string, AllowedPattern?: string, DataType?: string, Description?: string, KeyId?: string, Overwrite?: boolean, Policies?: any[], Tags?: any[], Tier?: string, Type?: string }) => Promise<PutParameterResponse>
+  PutParameter: (input: AwsLiteMethodOptions & { Name: string, Value: string, AllowedPattern?: string, DataType?: string, Description?: string, KeyId?: string, Overwrite?: boolean, Policies?: any[], Tags?: any[], Tier?: string, Type?: string }) => Promise<PutParameterResponse>
   // $METHODS_END
 }
 

--- a/plugins/sts/types/index.d.ts
+++ b/plugins/sts/types/index.d.ts
@@ -12,6 +12,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-sts";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLiteSTS {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START
@@ -20,45 +22,45 @@ declare interface AwsLiteSTS {
    * - AWS docs: {@link https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html STS: AssumeRole}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/sts/readme.md#AssumeRole STS: AssumeRole}
    */
-  AssumeRole: (input: { RoleArn: string, RoleSessionName: string, DurationSeconds?: number, ExternalId?: string, Policy?: string, PolicyArns?: any[], ProvidedContexts?: any[], SerialNumber?: string, SourceIdentity?: string, Tags?: any[], TokenCode?: string, TransitiveTagKeys?: any[] }) => Promise<AssumeRoleResponse>
+  AssumeRole: (input: AwsLiteMethodOptions & { RoleArn: string, RoleSessionName: string, DurationSeconds?: number, ExternalId?: string, Policy?: string, PolicyArns?: any[], ProvidedContexts?: any[], SerialNumber?: string, SourceIdentity?: string, Tags?: any[], TokenCode?: string, TransitiveTagKeys?: any[] }) => Promise<AssumeRoleResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithSAML.html STS: AssumeRoleWithSAML}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/sts/readme.md#AssumeRoleWithSAML STS: AssumeRoleWithSAML}
    */
-  AssumeRoleWithSAML: (input: { RoleArn: string, PrincipalArn: string, SAMLAssertion: string, DurationSeconds?: number, Policy?: string, PolicyArns?: any[] }) => Promise<AssumeRoleWithSAMLResponse>
+  AssumeRoleWithSAML: (input: AwsLiteMethodOptions & { RoleArn: string, PrincipalArn: string, SAMLAssertion: string, DurationSeconds?: number, Policy?: string, PolicyArns?: any[] }) => Promise<AssumeRoleWithSAMLResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html STS: AssumeRoleWithWebIdentity}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/sts/readme.md#AssumeRoleWithWebIdentity STS: AssumeRoleWithWebIdentity}
    */
-  AssumeRoleWithWebIdentity: (input: { RoleArn: string, RoleSessionName: string, WebIdentityToken: string, DurationSeconds?: number, ProviderId?: string, Policy?: string, PolicyArns?: any[] }) => Promise<AssumeRoleWithWebIdentityResponse>
+  AssumeRoleWithWebIdentity: (input: AwsLiteMethodOptions & { RoleArn: string, RoleSessionName: string, WebIdentityToken: string, DurationSeconds?: number, ProviderId?: string, Policy?: string, PolicyArns?: any[] }) => Promise<AssumeRoleWithWebIdentityResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/STS/latest/APIReference/API_DecodeAuthorizationMessage.html STS: DecodeAuthorizationMessage}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/sts/readme.md#DecodeAuthorizationMessage STS: DecodeAuthorizationMessage}
    */
-  DecodeAuthorizationMessage: (input: { EncodedMessage: string }) => Promise<DecodeAuthorizationMessageResponse>
+  DecodeAuthorizationMessage: (input: AwsLiteMethodOptions & { EncodedMessage: string }) => Promise<DecodeAuthorizationMessageResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/STS/latest/APIReference/API_GetAccessKeyInfo.html STS: GetAccessKeyInfo}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/sts/readme.md#GetAccessKeyInfo STS: GetAccessKeyInfo}
    */
-  GetAccessKeyInfo: (input: { AccessKeyId: string }) => Promise<GetAccessKeyInfoResponse>
+  GetAccessKeyInfo: (input: AwsLiteMethodOptions & { AccessKeyId: string }) => Promise<GetAccessKeyInfoResponse>
   /** @description aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/sts/readme.md#GetCallerIdentity STS: GetCallerIdentity} */
-  GetCallerIdentity: () => Promise<GetCallerIdentityResponse>
+  GetCallerIdentity: (input?: AwsLiteMethodOptions) => Promise<GetCallerIdentityResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/STS/latest/APIReference/API_GetFederationToken.html STS: GetFederationToken}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/sts/readme.md#GetFederationToken STS: GetFederationToken}
    */
-  GetFederationToken: (input: { Name: string, DurationSeconds?: number, Policy?: string, PolicyArns?: any[], Tags?: any[] }) => Promise<GetFederationTokenResponse>
+  GetFederationToken: (input: AwsLiteMethodOptions & { Name: string, DurationSeconds?: number, Policy?: string, PolicyArns?: any[], Tags?: any[] }) => Promise<GetFederationTokenResponse>
   /**
    * @description
    * - AWS docs: {@link https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html STS: GetSessionToken}
    * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/sts/readme.md#GetSessionToken STS: GetSessionToken}
    */
-  GetSessionToken: (input: { DurationSeconds?: number, SerialNumber?: string, TokenCode?: string }) => Promise<GetSessionTokenResponse>
+  GetSessionToken: (input: AwsLiteMethodOptions & { DurationSeconds?: number, SerialNumber?: string, TokenCode?: string }) => Promise<GetSessionTokenResponse>
   // $METHODS_END
 }
 

--- a/scripts/generate-plugins/_types.mjs
+++ b/scripts/generate-plugins/_types.mjs
@@ -77,11 +77,11 @@ function createTypesStr ({ methods, service, awsSdkName, property, display, exis
         descString.push(`   * - aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/${service}/readme.md#${method} ${display}: ${method}}`)
         descString.push('   */')
         methodTypes.push(descString.join('\n'))
-        methodTypes.push(`  ${method}: (input: { ${inputTypeString.join(', ')} }) => Promise<${methodResponse}>`)
+        methodTypes.push(`  ${method}: (input: AwsLiteMethodOptions & { ${inputTypeString.join(', ')} }) => Promise<${methodResponse}>`)
       }
       else {
         methodTypes.push(`  /** @description aws-lite docs: {@link https://github.com/aws-lite/aws-lite/blob/main/plugins/${service}/readme.md#${method} ${display}: ${method}} */`)
-        methodTypes.push(`  ${method}: () => Promise<${methodResponse}>`)
+        methodTypes.push(`  ${method}: (input?: AwsLiteMethodOptions) => Promise<${methodResponse}>`)
       }
     }
   }
@@ -89,9 +89,22 @@ function createTypesStr ({ methods, service, awsSdkName, property, display, exis
   const importsRegex = /(?<=(\/\/ \$IMPORTS_START\n))[\s\S]*?(?=(\/\/ \$IMPORTS_END))/g
   const methodsRegex = /(?<=(\/\/ \$METHODS_START\n))[\s\S]*?(?=(\/\/ \$METHODS_END))/g
   const exportRegex = /(?<=(\/\/ \$EXPORT_START\n))[\s\S]*?(?=(\/\/ \$EXPORT_END))/g
-  const typesTmpl = existingTypes
+  let typesTmpl = existingTypes
     ? existingTypes
     : readFileSync(join(__dirname, 'tmpl', '_types-tmpl.d.ts')).toString()
+
+  // Ensure AwsLiteMethodOptions import exists for existing files
+  if (existingTypes && !typesTmpl.includes('import type { AwsLiteMethodOptions }')) {
+    // Add the import after the AWS SDK import
+    const awsSdkImportEnd = typesTmpl.indexOf('} from "@aws-sdk/client-')
+    if (awsSdkImportEnd !== -1) {
+      const insertPoint = typesTmpl.indexOf(';\n', awsSdkImportEnd) + 2
+      typesTmpl = typesTmpl.slice(0, insertPoint) +
+                  '\nimport type { AwsLiteMethodOptions } from "@aws-lite/client";\n' +
+                  typesTmpl.slice(insertPoint)
+    }
+  }
+
   const trailingComma = outputTypes.length ? ',' : ''
   return typesTmpl
     .replace(/\$SERVICE/g, awsSdkName || service)

--- a/scripts/generate-plugins/tmpl/_types-tmpl.d.ts
+++ b/scripts/generate-plugins/tmpl/_types-tmpl.d.ts
@@ -4,6 +4,8 @@ import {
   // $IMPORTS_END
 } from "@aws-sdk/client-$SERVICE";
 
+import type { AwsLiteMethodOptions } from "@aws-lite/client";
+
 declare interface AwsLite$PROPERTY {
   /* ! Do not remove METHODS_START / METHODS_END ! */
   // $METHODS_START

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -48,6 +48,14 @@ interface AwsLiteResponse {
   statusCode: number;
 }
 
+// Base type for common parameters available on all plugin methods
+export interface AwsLiteMethodOptions {
+  /** Override the region for this specific method call */
+  region?: string;
+  /** Enable automatic pagination (true) or return an async iterator ('iterator') */
+  paginate?: boolean | 'iterator';
+}
+
 // export to allow <plugin>-types to extend AwsLiteClient
 export interface AwsLiteClient {
   (payload: AwsLiteRequest): Promise<AwsLiteResponse>;
@@ -76,6 +84,7 @@ interface AwsLiteTesting {
   reset: () => void;
 }
 
+// Module declaration for npm package imports (e.g., require('@aws-lite/client'))
 declare module "@aws-lite/client" {
   const CreateAwsLite: {
     (config?: AwsLiteConfig): Promise<AwsLiteClient>;


### PR DESCRIPTION
Adds an `AwsLiteMethodOptions` type and hook it into API client method generation. Fixes #186.

Before, trying to set `region` on an individual-API-call basis:

<img width="962" height="168" alt="Screenshot 2025-12-19 at 08 43 27" src="https://github.com/user-attachments/assets/5025046c-7a95-4b40-ab66-570cd1c8ad39" />

After, using this PR:

<img width="598" height="152" alt="Screenshot 2025-12-19 at 08 39 22" src="https://github.com/user-attachments/assets/200bb4ad-3914-4457-b078-bc6273c719c5" />
