### PR TITLE
fix: add method to AwsLiteRequest type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,6 +39,7 @@ declare namespace CreateAwsLite {
     data?: Record<string, any> | Buffer | ReadableStream | string;
     headers?: Record<string, string>;
     host?: string;
+    method?: string;
     path?: string;
     payload?: Record<string, any> | Buffer | ReadableStream | string;
     port?: number;

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -123,6 +123,14 @@ awsLite().then((client) => {
     verifyService: false,
   })
 
+  // Test: method
+  client({
+    service: 'scheduler',
+    method: 'GET',
+    path: `/schedules/${encodeURIComponent('my-name')}`,
+    query: { groupName: 'default' },
+  })
+
   return client
 })
 


### PR DESCRIPTION
Adding `method` into `AwsLiteRequest`.
