### PR TITLE
Conform to AWS CLI's interpretation of comments in ini files

### DIFF
--- a/_changelog.md
+++ b/_changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [0.24.0] 2026-??-??
+
+### Fixed
+
+- Conform to AWS CLI's interpretation of comments in ini files. The AWS CLI does not support inline comments for key-value pairs. Comments are only supported by starting a line with `#`. This has implications for correctly supporting lookup of cached SSO sessions.
+
+---
+
 ## [0.23.6] 2025-04-10
 
 ### Added

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -180,7 +180,7 @@ function isInLambda () {
 // mhart's fairly strict INI parser – only deals with alpha keys, data must be within sections
 // Adapted from: https://github.com/mhart/awscred
 // Added support for inline + whole line comments
-let iniRegex = /^\[([^\]]+)\]\s*(?:#.*)?$|^([a-z_]+)\s*=\s*(.+?)\s*(?:#.*)?$/
+let iniRegex = /^\[([^\]]+)\]\s*(?:#.*)?$|^([a-z_]+)\s*=\s*(.+?)\s*$/
 function parseAwsIni (ini) {
   let section
   let out = Object.create(null)

--- a/test/unit/src/lib/index-test.mjs
+++ b/test/unit/src/lib/index-test.mjs
@@ -121,7 +121,7 @@ test('readIni', async t => {
   t.equal(config.default.aws_access_key_id, 'default_aws_access_key_id', 'Loaded default access key with inline comments')
   t.equal(config.default.aws_secret_access_key, 'default_aws_secret_access_key', 'Loaded default secret key')
   // Profile 1
-  t.equal(config.profile_1.aws_access_key_id, 'profile_1_aws_access_key_id', 'Loaded profile_1 access key with inline comments')
+  t.equal(config.profile_1.aws_access_key_id, 'profile_1_aws_access_key_id             # henlo', 'Loaded profile_1 access key, including unsuccessful hash comment')
   t.equal(config.profile_1.aws_secret_access_key, 'profile_1_aws_secret_access_key ; ok', 'Loaded profile_1 access key, including unsuccessful semicolon comment')
   t.notOk(config.profile_1.ignore, 'Did not load commented line')
   t.notOk(config.profile_1.ignore_this, 'Did not load commented line')


### PR DESCRIPTION
The AWS CLI does not support inline comments for key-value pairs. Comments are only supported by starting a line with `#`. This has implications for correctly supporting lookup of cached SSO sessions. For example, the following `~/.aws/config` file fragment:

```
[profile foobar]
sso_start_url = https://example.com/#
```

should be interpreted as setting the value of `sso_start_url` to `https://example.com/#`.

On the other hand, inline comments _are_ supported for bracketed section lines, like `[profile foobar] # my profile`.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [x] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [x] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [x] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
