### PR TITLE
fix: s3 content-length bug fix using byteLength

### DIFF
--- a/_changelog.md
+++ b/_changelog.md
@@ -2,6 +2,13 @@
 
 ---
 
+## [0.23.7] 2026-06-09
+
+### Fixed
+
+- `S3.PutObject` now gets `Content-Length` from the UTF-8 byte length of a string `Body` instead of its JS string length. Multi-byte characters (emoji, accented letters, CJK) were under counting `Content-Length`. The truncated body caused S3 to reject the upload with a 400 error.
+---
+
 ## [0.23.6] 2025-04-10
 
 ### Added

--- a/plugins/s3/src/put-object.mjs
+++ b/plugins/s3/src/put-object.mjs
@@ -66,7 +66,7 @@ const PutObject = {
     }
 
     if (Body) {
-      dataSize = Body.length
+      dataSize = Buffer.byteLength(Body)
     }
     else {
       try {

--- a/plugins/s3/test/s3-test.mjs
+++ b/plugins/s3/test/s3-test.mjs
@@ -1,6 +1,7 @@
 import { join } from 'node:path'
 import test from 'tape'
 import mockTmp from 'mock-tmp'
+import PutObject from '../src/put-object.mjs'
 import { parseXML } from '../../../src/lib/index.js'
 import { defaults } from '../../../test/lib/index.mjs'
 let { config } = defaults
@@ -283,4 +284,28 @@ test('Tear down env', async t => {
   client.testing.disable()
   mockTmp.reset()
   t.pass(`mockTmp removed`)
+})
+
+let putObjectUtils = { config, credentials: {}, region }
+// String length 25, UTF-8 byte length 34
+let multibyteBody = JSON.stringify({ message: 'café 🚀 日本語' })
+
+test('PutObject Content-Length is the UTF-8 byte length of a multi-byte string Body', async t => {
+  t.plan(1)
+  let { headers } = await PutObject.request({ Bucket: bucketName, Key: objectNames[1], Body: multibyteBody }, putObjectUtils)
+  t.equal(headers['content-length'], Buffer.byteLength(multibyteBody), 'Content-Length is the byte length, not the string length')
+})
+
+test('PutObject Content-Length is the byte length of a multi-byte Buffer Body', async t => {
+  t.plan(1)
+  let Body = Buffer.from(multibyteBody)
+  let { headers } = await PutObject.request({ Bucket: bucketName, Key: objectNames[1], Body }, putObjectUtils)
+  t.equal(headers['content-length'], Body.length, 'Content-Length is the buffer byte length')
+})
+
+test('PutObject Content-Length is unchanged for an ASCII string Body', async t => {
+  t.plan(1)
+  let Body = objectContents[1]
+  let { headers } = await PutObject.request({ Bucket: bucketName, Key: objectNames[1], Body }, putObjectUtils)
+  t.equal(headers['content-length'], Buffer.byteLength(Body), 'Content-Length is correct for ASCII strings')
 })


### PR DESCRIPTION
When sending strings to S3 using the S3 plugin the javascript length is used to set the content-length. When special characters and some emoji's are used the JS length does not match the Buffer that is actually sent. This responds with an 400 error. Tests demonstrating the issue are included.